### PR TITLE
Add skip navigation link

### DIFF
--- a/accounts/templates/account/login.html
+++ b/accounts/templates/account/login.html
@@ -21,7 +21,7 @@
 {% endblock subheader %}
 
 {% block content %}
-
+  <main id="main">
     <div class="padding-vertical-3">
         <div class="grid-container">
             <h1 class="title">Login</h1>
@@ -47,4 +47,5 @@
 
         </div>
     </div>
+  </main>
 {% endblock %}

--- a/weallcode/static/weallcode/css/app.css
+++ b/weallcode/static/weallcode/css/app.css
@@ -754,15 +754,15 @@ body.home .free-programs {
 
 /* Fix link on specific background colors */
 
-main .bg-dark-blue a,
-main .bg-primary a {
+.class-info-box .bg-dark-blue a:not(.button),
+.class-info-box .bg-primary a:not(.button) {
   color: var(--white);
   border-bottom: 1px solid var(--white);
 }
 
-main .bg-dark-blue a:focus,
-main .bg-dark-blue a:hover,
-main .bg-bg-primary a:focus,
-main .bg-bg-primary a:hover {
+.class-info-box .bg-dark-blue a:not(.button):focus,
+.class-info-box .bg-dark-blue a:not(.button):hover,
+.class-info-box .bg-bg-primary a:not(.button):focus,
+.class-info-box .bg-bg-primary a:not(.button):hover {
   border-bottom-width: 3px;
 }

--- a/weallcode/templates/weallcode/_base.html
+++ b/weallcode/templates/weallcode/_base.html
@@ -44,7 +44,7 @@
   <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="https://browsehappy.com/">upgrade your browser</a> to improve your experience and security.</p>
   <![endif]-->
   {% spaceless %}{% include 'weallcode/_svgs.html' %}{% endspaceless %}
-
+  <a href="#main" class="show-for-sr show-on-focus">Skip to main content</a>
   <div class="app">
     <header class="bg-dark-blue">
       {% block header %}{% include 'weallcode/_header.html' %}{% endblock %}

--- a/weallcode/templates/weallcode/_base.html
+++ b/weallcode/templates/weallcode/_base.html
@@ -60,7 +60,7 @@
     {% endblock %}
 
     {% block content %}
-    <main class="margin-vertical-3">
+    <main id="main" class="margin-vertical-3">
       <div class="grid-container">
         {% block contained_content %}
         {% endblock %}

--- a/weallcode/templates/weallcode/associate_board.html
+++ b/weallcode/templates/weallcode/associate_board.html
@@ -26,9 +26,9 @@
 
 {% block content %}
 
-  <main id="main">
-    {% include "weallcode/snippets/hero_image.html" with src="weallcode/images/photos/hero-associate-board.jpg" alt="Associate Board" %}
+  {% include "weallcode/snippets/hero_image.html" with src="weallcode/images/photos/hero-associate-board.jpg" alt="Associate Board" %}
 
+  <main id="main">
     <!-- Introduction -->
     <section id="introduction" class="padding-top-3">
       <div class="grid-container">

--- a/weallcode/templates/weallcode/associate_board.html
+++ b/weallcode/templates/weallcode/associate_board.html
@@ -26,156 +26,157 @@
 
 {% block content %}
 
-  {% include "weallcode/snippets/hero_image.html" with src="weallcode/images/photos/hero-associate-board.jpg" alt="Associate Board" %}
+  <main id="main">
+    {% include "weallcode/snippets/hero_image.html" with src="weallcode/images/photos/hero-associate-board.jpg" alt="Associate Board" %}
 
-  <!-- Introduction -->
-  <section id="introduction" class="padding-top-3">
-    <div class="grid-container">
-      <div class="grid-x margin-bottom-2">
-        <div class="cell large-8 padding-right-2">
-          <h1 class="title text-tertiary">Associate Board</h1>
-          <p>Joining We All Code's Associate Board is an exciting opportunity for early- to mid-career professionals who want to contribute their time, talent, and treasure to We All Code's mission, while building professional networks and enhancing leadership skills.</p>
-        </div>
-        <div class="cell large-4 position-relative">
-          <div class="aside-title">
-            <div>
-              <span class="text-tertiary display-inline-block">Educate the </span>
-              <span class="text-tertiary display-inline-block">technology </span>
-              <span class="text-secondary display-inline-block">leaders of </span>
-              <span class="text-white display-inline-block">tomorrow</span>
+    <!-- Introduction -->
+    <section id="introduction" class="padding-top-3">
+      <div class="grid-container">
+        <div class="grid-x margin-bottom-2">
+          <div class="cell large-8 padding-right-2">
+            <h1 class="title text-tertiary">Associate Board</h1>
+            <p>Joining We All Code's Associate Board is an exciting opportunity for early- to mid-career professionals who want to contribute their time, talent, and treasure to We All Code's mission, while building professional networks and enhancing leadership skills.</p>
+          </div>
+          <div class="cell large-4 position-relative">
+            <div class="aside-title">
+              <div>
+                <span class="text-tertiary display-inline-block">Educate the </span>
+                <span class="text-tertiary display-inline-block">technology </span>
+                <span class="text-secondary display-inline-block">leaders of </span>
+                <span class="text-white display-inline-block">tomorrow</span>
+              </div>
+              <div class="line width-25 bg-primary margin-top-1"></div>
             </div>
-            <div class="line width-25 bg-primary margin-top-1"></div>
+          </div>
+        </div>
+
+        <div class="grid-x grid-padding-x margin-vertical-2">
+          <div class="cell medium-8">
+            <h3 class="title text-primary">Overview</h3>
+
+            <p>The Associate Board provides an excellent opportunity for interested volunteers at an early stage in their careers to contribute to We All Code's mission on many levels (devoting time, treasure, talent) while building professional networks and enhancing leadership skills.</p>
+
+            <p>The work of the Associate Board will focus on the following guiding principles:</p>
+
+            <ol class="list-plus">
+              <li>Elevate the presence of We All Code across Chicago and enhance visibility for our programs;</li>
+              <li>Raise funds and engage new potential donors to support the development of future leaders; and</li>
+              <li>Create opportunities outside of the organization for engagement with young students.</li>
+            </ol>
           </div>
         </div>
       </div>
+    </section>
 
-      <div class="grid-x grid-padding-x margin-vertical-2">
-        <div class="cell medium-8">
-          <h3 class="title text-primary">Overview</h3>
+    {% include "weallcode/snippets/hero_image.html" with src="weallcode/images/photos/hero-team.jpg" alt="Associate Board" %}
 
-          <p>The Associate Board provides an excellent opportunity for interested volunteers at an early stage in their careers to contribute to We All Code's mission on many levels (devoting time, treasure, talent) while building professional networks and enhancing leadership skills.</p>
+    <!-- More Introduction -->
+    <section id="more-information" class="padding-top-3">
+      <div class="grid-container">
+        <div class="grid-x grid-padding-x margin-bottom-3">
+          <div class="cell medium-6">
+            <h3 class="title text-primary">Benefits of an Associate Board Membership</h3>
 
-          <p>The work of the Associate Board will focus on the following guiding principles:</p>
+            <ul class="list-plus">
+              <li>Friend-raising and networking experience</li>
+              <li>Leadership development experience and mentoring with the Board of Directors</li>
+              <li>Mentoring opportunities</li>
+              <li>Name recognition on Board invitations (when appropriate)</li>
+              <li>Recognition in the organization's Annual Report</li>
+              <li>Opportunities to enjoy special privileges such as behind-the-scenes tours and previews of new programs and initiatives</li>
+            </ul>
+          </div>
+          <div class="cell medium-6">
+            <div class="binary-drop-right">
+              <img class="width-100" src="{% static 'weallcode/images/photos/volunteering-2.jpg' %}" alt="Photo of student and mentor in class.">
+            </div>
+          </div>
+        </div>
 
-          <ol class="list-plus">
-            <li>Elevate the presence of We All Code across Chicago and enhance visibility for our programs;</li>
-            <li>Raise funds and engage new potential donors to support the development of future leaders; and</li>
-            <li>Create opportunities outside of the organization for engagement with young students.</li>
-          </ol>
+        <div class="grid-x grid-padding-x margin-bottom-3">
+
+          <div class="cell medium-8">
+            <h3 class="title text-primary">Membership Requirements</h3>
+
+            <ul class="list-plus">
+              <li>A passion for building future leaders and a commitment to developing students of courage, confidence and character.</li>
+              <li>Personally donate $250 (give) and work to bring in additional $500 (get) through personal/professional networks throughout the year.</li>
+              <li>Be an enthusiastic advocate for the mission of We All Code, especially among Chicago's young professional community.</li>
+              <li>Attend at least 75% of scheduled meetings, though attendance at all meetings is strongly encouraged.</li>
+              <li>Join an Associate Board committee.</li>
+              <li>Support fundraising events. This would include at least two of the following:
+                <ul class="list-plus">
+                  <li>Secure monetary or in-kind donations.</li>
+                  <li>Purchase at least one ticket and attend the event(s)</li>
+                  <li>Make a personal financial donation towards the event if unable to attend</li>
+                  <li>Purchase raffle tickets, silent auction items, etc. (if applicable)</li>
+                </ul>
+              </li>
+              <li>Engage personal and professional networks and/or companies to support the organization at-large and Associate Board-specific events.</li>
+              <li>Commit to building students of courage, confidence and character, who make the world a better place and be passionate about developing future leaders.</li>
+            </ul>
+
+            <p>The Associate Board currently consists of approximately 15 members. We aspire to grow while keeping membership limited. Our target members are professionals, entrepreneurs, and civic leaders in the first 5-10 years of their careers. Membership on the Associate Board is open to anyone who is passionate about We All Code's mission and interested in supporting the work we do.</p>
+          </div>
+        </div>
+
+        <div class="grid-x grid-padding-x margin-bottom-2">
+          <div class="cell medium-8">
+            <h3 class="title text-primary">Fundraising Goal</h3>
+
+            <p>Each year, the Associate Board works with its liaison(s) from the Board of Directors to establish a fundraising goal for the fall event in addition to the Associate Board give/get requirements.</p>
+          </div>
+        </div>
+
+        <div class="grid-x grid-padding-x margin-bottom-2">
+          <div class="cell medium-6">
+            <h3 class="title text-primary margin-bottom-2">Associate Board Committees</h3>
+
+            <p><strong>Outreach</strong> - The Associate Board Outreach Committee works to increase the reach of We All Code, build a network/pipeline, and ensure that multiple dimensions of We All Code are represented.</p>
+
+            <p><strong>Fundraising</strong> - The Associate Board Fundraising Committee uses creativity and connections, with a We All Code focus, to lead the annual fall event. This Committee focuses on leading the full Associate Board through the process of securing sponsorships, selling tickets, securing silent auction items, and creating an event that is engaging and mission-oriented.</p>
+
+            <p><strong>Volunteer</strong> - The Associate Board Volunteer Committee works to create opportunities that engage the Associate Board members with the mission of the organization in a hands-on, meaningful way that also creates social interaction with each other.</p>
+
+            <h3 class="title text-primary margin-vertical-2">Questions?</h3>
+
+            <p>Please contact us at <a href="mailto:hello@weallcode.org">hello@weallcode.org</a> for any questions or more information.</p>
+
+          </div>
+          <div class="cell medium-6">
+            <div class="binary-drop-right">
+              <img class="width-100" src="{% static 'weallcode/images/photos/volunteering-3-small.jpg' %}" alt="Photo of student and mentor in class.">
+            </div>
+          </div>
+        </div>
+
+        <div class="text-center margin-bottom-2">
+          <a class="button large" href="{% url 'weallcode-associate-board' %}#form">Apply to the Associate Board</a>
         </div>
       </div>
-    </div>
-  </section>
+    </section>
 
-  {% include "weallcode/snippets/hero_image.html" with src="weallcode/images/photos/hero-team.jpg" alt="Associate Board" %}
+    <!-- Form -->
+    <section id="form" class="bg-binary padding-vertical-2">
+      <div class="grid-container">
+        <div class="grid-x margin-vertical-3">
+          <div class="cell medium-8 bg-white">
+            <h2 class="title text-primary padding-horizontal-2 padding-top-2">Apply to join the Associate Board</h2>
+            <p class="padding-horizontal-2"><strong>Don't miss this unique opportunity to give back to the Chicago community!</strong></p>
 
-  <!-- More Introduction -->
-  <section id="more-information" class="padding-top-3">
-    <div class="grid-container">
-      <div class="grid-x grid-padding-x margin-bottom-3">
-        <div class="cell medium-6">
-          <h3 class="title text-primary">Benefits of an Associate Board Membership</h3>
-
-          <ul class="list-plus">
-            <li>Friend-raising and networking experience</li>
-            <li>Leadership development experience and mentoring with the Board of Directors</li>
-            <li>Mentoring opportunities</li>
-            <li>Name recognition on Board invitations (when appropriate)</li>
-            <li>Recognition in the organization's Annual Report</li>
-            <li>Opportunities to enjoy special privileges such as behind-the-scenes tours and previews of new programs and initiatives</li>
-          </ul>
-        </div>
-        <div class="cell medium-6">
-          <div class="binary-drop-right">
-            <img class="width-100" src="{% static 'weallcode/images/photos/volunteering-2.jpg' %}" alt="Photo of student and mentor in class.">
+            <iframe src="https://docs.google.com/forms/d/e/1FAIpQLScKzZFNOjjsuRDtEw8VsR98_8MSq38SoyGDdlmfh1ibFJLOcw/viewform?embedded=true" width="100%" height="1000" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
+          </div>
+          <div class="cell medium-4 bg-dark-blue text-white padding-2">
+            <div class="line bg-secondary width-25 margin-bottom-3"></div>
+            <div class="text-huge text-uppercase text-bold line-height-1 margin-bottom-2">
+              <span class="text-primary">Help us eliminate</span>
+              <span class="text-secondary">the barriers preventing</span>
+              <span class="text-tertiary">all Chicago kids from</span>
+              <span>learning to code.</span>
+            </div>
           </div>
         </div>
       </div>
-
-      <div class="grid-x grid-padding-x margin-bottom-3">
-
-        <div class="cell medium-8">
-          <h3 class="title text-primary">Membership Requirements</h3>
-
-          <ul class="list-plus">
-            <li>A passion for building future leaders and a commitment to developing students of courage, confidence and character.</li>
-            <li>Personally donate $250 (give) and work to bring in additional $500 (get) through personal/professional networks throughout the year.</li>
-            <li>Be an enthusiastic advocate for the mission of We All Code, especially among Chicago's young professional community.</li>
-            <li>Attend at least 75% of scheduled meetings, though attendance at all meetings is strongly encouraged.</li>
-            <li>Join an Associate Board committee.</li>
-            <li>Support fundraising events. This would include at least two of the following:
-              <ul class="list-plus">
-                <li>Secure monetary or in-kind donations.</li>
-                <li>Purchase at least one ticket and attend the event(s)</li>
-                <li>Make a personal financial donation towards the event if unable to attend</li>
-                <li>Purchase raffle tickets, silent auction items, etc. (if applicable)</li>
-              </ul>
-            </li>
-            <li>Engage personal and professional networks and/or companies to support the organization at-large and Associate Board-specific events.</li>
-            <li>Commit to building students of courage, confidence and character, who make the world a better place and be passionate about developing future leaders.</li>
-          </ul>
-
-          <p>The Associate Board currently consists of approximately 15 members. We aspire to grow while keeping membership limited. Our target members are professionals, entrepreneurs, and civic leaders in the first 5-10 years of their careers. Membership on the Associate Board is open to anyone who is passionate about We All Code's mission and interested in supporting the work we do.</p>
-        </div>
-      </div>
-
-      <div class="grid-x grid-padding-x margin-bottom-2">
-        <div class="cell medium-8">
-          <h3 class="title text-primary">Fundraising Goal</h3>
-
-          <p>Each year, the Associate Board works with its liaison(s) from the Board of Directors to establish a fundraising goal for the fall event in addition to the Associate Board give/get requirements.</p>
-        </div>
-      </div>
-
-      <div class="grid-x grid-padding-x margin-bottom-2">
-        <div class="cell medium-6">
-          <h3 class="title text-primary margin-bottom-2">Associate Board Committees</h3>
-
-          <p><strong>Outreach</strong> - The Associate Board Outreach Committee works to increase the reach of We All Code, build a network/pipeline, and ensure that multiple dimensions of We All Code are represented.</p>
-
-          <p><strong>Fundraising</strong> - The Associate Board Fundraising Committee uses creativity and connections, with a We All Code focus, to lead the annual fall event. This Committee focuses on leading the full Associate Board through the process of securing sponsorships, selling tickets, securing silent auction items, and creating an event that is engaging and mission-oriented.</p>
-
-          <p><strong>Volunteer</strong> - The Associate Board Volunteer Committee works to create opportunities that engage the Associate Board members with the mission of the organization in a hands-on, meaningful way that also creates social interaction with each other.</p>
-
-          <h3 class="title text-primary margin-vertical-2">Questions?</h3>
-
-          <p>Please contact us at <a href="mailto:hello@weallcode.org">hello@weallcode.org</a> for any questions or more information.</p>
-
-        </div>
-        <div class="cell medium-6">
-          <div class="binary-drop-right">
-            <img class="width-100" src="{% static 'weallcode/images/photos/volunteering-3-small.jpg' %}" alt="Photo of student and mentor in class.">
-          </div>
-        </div>
-      </div>
-
-      <div class="text-center margin-bottom-2">
-        <a class="button large" href="{% url 'weallcode-associate-board' %}#form">Apply to the Associate Board</a>
-      </div>
-    </div>
-  </section>
-
-  <!-- Form -->
-  <section id="form" class="bg-binary padding-vertical-2">
-    <div class="grid-container">
-      <div class="grid-x margin-vertical-3">
-        <div class="cell medium-8 bg-white">
-          <h2 class="title text-primary padding-horizontal-2 padding-top-2">Apply to join the Associate Board</h2>
-          <p class="padding-horizontal-2"><strong>Don't miss this unique opportunity to give back to the Chicago community!</strong></p>
-
-          <iframe src="https://docs.google.com/forms/d/e/1FAIpQLScKzZFNOjjsuRDtEw8VsR98_8MSq38SoyGDdlmfh1ibFJLOcw/viewform?embedded=true" width="100%" height="1000" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
-        </div>
-        <div class="cell medium-4 bg-dark-blue text-white padding-2">
-          <div class="line bg-secondary width-25 margin-bottom-3"></div>
-          <div class="text-huge text-uppercase text-bold line-height-1 margin-bottom-2">
-            <span class="text-primary">Help us eliminate</span>
-            <span class="text-secondary">the barriers preventing</span>
-            <span class="text-tertiary">all Chicago kids from</span>
-            <span>learning to code.</span>
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
-
+    </section>
+  </main>
 {% endblock %}

--- a/weallcode/templates/weallcode/home.html
+++ b/weallcode/templates/weallcode/home.html
@@ -5,39 +5,39 @@
 {% block page-class %}home{% endblock %}
 
 {% block content %}
-  <main id="main">
-    <!-- Hero -->
-    <section class="padding-vertical-3 bg-kid-overlay">
-      <div class="grid-container">
-        <div class="grid-x grid-padding-x grid-padding-y padding-bottom-1">
-          <div class="cell medium-6 text-white">
-            <h1 class="title">Let's explore<br> your coding<br> curiosity.</h1>
-            <p>Our mission is to introduce a diverse group of children to the fun of coding by providing free educational resources and hands-on classes.</p>
-          </div>
-          <div class="cell medium-5 medium-offset-1 large-4 large-offset-2">
-            {% if next_session %}
-              <div class="bg-dark-blue text-center radius overlap-bottom">
-                <h6 class="text-uppercase padding-1 margin-0 text-grey-for-white">Upcoming class</h6>
-                <div class="padding-1 padding-horizontal-2 bg-white">
-                  <h4 class="text-blue text-uppercase text-primary"><a href="{{ next_session.get_absolute_url }}"><strong>{{ next_session.course.code  }}</strong></a></h4>
-                  <div><strong>{{ next_session.course.title }}</strong></div>
-                  <div>{{ next_session.start_date|date }}</div>
-                  <div class="line bg-secondary width-25 margin-vertical-half"></div>
-                  <div>{{ next_session.location.name }}</div>
-                  {% if next_session.location.address %}
-                  <div>{{ next_session.location.address }}</div>
-                  <div>{{ next_session.location.city }} {{ next_session.location.state }} {{ next_session.location.zip }}</div>
-                  {% endif %}
-                  <a class="button bg-tertiary width-100 margin-top-1" href="{{ next_session.get_absolute_url }}">Enroll Now</a>
-                  <a href="{% url 'weallcode-programs' %}#classes"><small>View All Classes</small></a>
-                </div>
+  <!-- Hero -->
+  <section class="padding-vertical-3 bg-kid-overlay">
+    <div class="grid-container">
+      <div class="grid-x grid-padding-x grid-padding-y padding-bottom-1">
+        <div class="cell medium-6 text-white">
+          <h1 class="title">Let's explore<br> your coding<br> curiosity.</h1>
+          <p>Our mission is to introduce a diverse group of children to the fun of coding by providing free educational resources and hands-on classes.</p>
+        </div>
+        <div class="cell medium-5 medium-offset-1 large-4 large-offset-2">
+          {% if next_session %}
+            <div class="bg-dark-blue text-center radius overlap-bottom">
+              <h6 class="text-uppercase padding-1 margin-0 text-grey-for-white">Upcoming class</h6>
+              <div class="padding-1 padding-horizontal-2 bg-white">
+                <h4 class="text-blue text-uppercase text-primary"><a href="{{ next_session.get_absolute_url }}"><strong>{{ next_session.course.code  }}</strong></a></h4>
+                <div><strong>{{ next_session.course.title }}</strong></div>
+                <div>{{ next_session.start_date|date }}</div>
+                <div class="line bg-secondary width-25 margin-vertical-half"></div>
+                <div>{{ next_session.location.name }}</div>
+                {% if next_session.location.address %}
+                <div>{{ next_session.location.address }}</div>
+                <div>{{ next_session.location.city }} {{ next_session.location.state }} {{ next_session.location.zip }}</div>
+                {% endif %}
+                <a class="button bg-tertiary width-100 margin-top-1" href="{{ next_session.get_absolute_url }}">Enroll Now</a>
+                <a href="{% url 'weallcode-programs' %}#classes"><small>View All Classes</small></a>
               </div>
-            {% endif %}
-          </div>
+            </div>
+          {% endif %}
         </div>
       </div>
-    </section>
+    </div>
+  </section>
 
+  <main id="main">
     <!-- Newsletter -->
     <section class="padding-vertical-2 bg-binary">
       <div class="learn-more-signup">

--- a/weallcode/templates/weallcode/home.html
+++ b/weallcode/templates/weallcode/home.html
@@ -5,179 +5,181 @@
 {% block page-class %}home{% endblock %}
 
 {% block content %}
-  <!-- Hero -->
-  <section class="padding-vertical-3 bg-kid-overlay">
-    <div class="grid-container">
-      <div class="grid-x grid-padding-x grid-padding-y padding-bottom-1">
-        <div class="cell medium-6 text-white">
-          <h1 class="title">Let's explore<br> your coding<br> curiosity.</h1>
-          <p>Our mission is to introduce a diverse group of children to the fun of coding by providing free educational resources and hands-on classes.</p>
+  <main id="main">
+    <!-- Hero -->
+    <section class="padding-vertical-3 bg-kid-overlay">
+      <div class="grid-container">
+        <div class="grid-x grid-padding-x grid-padding-y padding-bottom-1">
+          <div class="cell medium-6 text-white">
+            <h1 class="title">Let's explore<br> your coding<br> curiosity.</h1>
+            <p>Our mission is to introduce a diverse group of children to the fun of coding by providing free educational resources and hands-on classes.</p>
+          </div>
+          <div class="cell medium-5 medium-offset-1 large-4 large-offset-2">
+            {% if next_session %}
+              <div class="bg-dark-blue text-center radius overlap-bottom">
+                <h6 class="text-uppercase padding-1 margin-0 text-grey-for-white">Upcoming class</h6>
+                <div class="padding-1 padding-horizontal-2 bg-white">
+                  <h4 class="text-blue text-uppercase text-primary"><a href="{{ next_session.get_absolute_url }}"><strong>{{ next_session.course.code  }}</strong></a></h4>
+                  <div><strong>{{ next_session.course.title }}</strong></div>
+                  <div>{{ next_session.start_date|date }}</div>
+                  <div class="line bg-secondary width-25 margin-vertical-half"></div>
+                  <div>{{ next_session.location.name }}</div>
+                  {% if next_session.location.address %}
+                  <div>{{ next_session.location.address }}</div>
+                  <div>{{ next_session.location.city }} {{ next_session.location.state }} {{ next_session.location.zip }}</div>
+                  {% endif %}
+                  <a class="button bg-tertiary width-100 margin-top-1" href="{{ next_session.get_absolute_url }}">Enroll Now</a>
+                  <a href="{% url 'weallcode-programs' %}#classes"><small>View All Classes</small></a>
+                </div>
+              </div>
+            {% endif %}
+          </div>
         </div>
-        <div class="cell medium-5 medium-offset-1 large-4 large-offset-2">
-          {% if next_session %}
-            <div class="bg-dark-blue text-center radius overlap-bottom">
-              <h6 class="text-uppercase padding-1 margin-0 text-grey-for-white">Upcoming class</h6>
-              <div class="padding-1 padding-horizontal-2 bg-white">
-                <h4 class="text-blue text-uppercase text-primary"><a href="{{ next_session.get_absolute_url }}"><strong>{{ next_session.course.code  }}</strong></a></h4>
-                <div><strong>{{ next_session.course.title }}</strong></div>
-                <div>{{ next_session.start_date|date }}</div>
-                <div class="line bg-secondary width-25 margin-vertical-half"></div>
-                <div>{{ next_session.location.name }}</div>
-                {% if next_session.location.address %}
-                <div>{{ next_session.location.address }}</div>
-                <div>{{ next_session.location.city }} {{ next_session.location.state }} {{ next_session.location.zip }}</div>
-                {% endif %}
-                <a class="button bg-tertiary width-100 margin-top-1" href="{{ next_session.get_absolute_url }}">Enroll Now</a>
-                <a href="{% url 'weallcode-programs' %}#classes"><small>View All Classes</small></a>
+      </div>
+    </section>
+
+    <!-- Newsletter -->
+    <section class="padding-vertical-2 bg-binary">
+      <div class="learn-more-signup">
+        <h2 class="learn-more-signup-title">Weekly Newsletter</h2>
+        <p class="learn-more-signup-subtitle">Stay up to date on our class schedule, upcoming courses, and useful resources.</p>
+
+        <div class="learn-more-signup-form">
+          <form action="https://weallcode.us2.list-manage.com/subscribe/post?u=1cf2aba5bf83d6c4ff8bdda35&amp;id=57426673d0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+            <div>
+              <div class="mc-field-group">
+                <label for="mce-EMAIL">Email Address </label>
+                <input type="email" value="" name="EMAIL" class="required email" placeholder="awesome.parent@gmail.com" id="mce-EMAIL">
+              </div>
+
+              <div id="mce-responses" class="clear">
+                <div class="response" id="mce-error-response" style="display:none"></div>
+                <div class="response" id="mce-success-response" style="display:none"></div>
+              </div>
+
+              <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+              <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_1cf2aba5bf83d6c4ff8bdda35_57426673d0" tabindex="-1" value=""></div>
+
+              <div class="clear">
+                <input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button">
               </div>
             </div>
-          {% endif %}
+          </form>
         </div>
       </div>
-    </div>
-  </section>
+    </section>
 
-  <!-- Newsletter -->
-  <section class="padding-vertical-2 bg-binary">
-    <div class="learn-more-signup">
-      <h2 class="learn-more-signup-title">Weekly Newsletter</h2>
-      <p class="learn-more-signup-subtitle">Stay up to date on our class schedule, upcoming courses, and useful resources.</p>
-
-      <div class="learn-more-signup-form">
-        <form action="https://weallcode.us2.list-manage.com/subscribe/post?u=1cf2aba5bf83d6c4ff8bdda35&amp;id=57426673d0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-          <div>
-            <div class="mc-field-group">
-              <label for="mce-EMAIL">Email Address </label>
-              <input type="email" value="" name="EMAIL" class="required email" placeholder="awesome.parent@gmail.com" id="mce-EMAIL">
-            </div>
-
-            <div id="mce-responses" class="clear">
-              <div class="response" id="mce-error-response" style="display:none"></div>
-              <div class="response" id="mce-success-response" style="display:none"></div>
-            </div>
-
-            <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-            <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_1cf2aba5bf83d6c4ff8bdda35_57426673d0" tabindex="-1" value=""></div>
-
-            <div class="clear">
-              <input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button">
+    <!-- Impact -->
+    <section class="margin-vertical-3">
+      <div class="grid-container">
+        <div class="grid-x grid-padding-x padding-bottom-1">
+          <div class="medium-6 cell">
+            <div class="binary-drop-left">
+              <img class="width-100 margin-bottom-1" src="{% static 'weallcode/images/photos/real-coding-skills.jpg' %}" alt="After class photo">
             </div>
           </div>
-        </form>
-      </div>
-    </div>
-  </section>
-
-  <!-- Impact -->
-  <section class="margin-vertical-3">
-    <div class="grid-container">
-      <div class="grid-x grid-padding-x padding-bottom-1">
-        <div class="medium-6 cell">
-          <div class="binary-drop-left">
-            <img class="width-100 margin-bottom-1" src="{% static 'weallcode/images/photos/real-coding-skills.jpg' %}" alt="After class photo">
+          <div class="medium-6 cell">
+            <h2 class="title text-primary">Real coding skills for every kid.</h2>
+            <p>We help young people from 7-17 envision a future in STEM and gain the coding skills to make it real.</p>
+            <a class="button secondary" href="{% url 'weallcode-programs' %}#courses">View Our Courses</a>
           </div>
         </div>
-        <div class="medium-6 cell">
-          <h2 class="title text-primary">Real coding skills for every kid.</h2>
-          <p>We help young people from 7-17 envision a future in STEM and gain the coding skills to make it real.</p>
-          <a class="button secondary" href="{% url 'weallcode-programs' %}#courses">View Our Courses</a>
+      </div>
+    </section>
+
+    <!-- Core Values -->
+    <section class="margin-bottom-3">
+      <div class="grid-container">
+        <div class="grid-x grid-padding-x">
+          <div class="small-6 small-offset-3">
+            <h2 class="title text-tertiary text-center">Core Values</h2>
+          </div>
+        </div>
+
+        {% include "weallcode/snippets/posters.html" with svg_href_1="#svg-intellectual" title_1="Open Mind" content_1="We emphasize fast-paced, experiential learning in an engaging and iterative format." svg_href_2="#svg-respect" title_2="Support" content_2="Our close 2:1 student-to-mentor ratio ensures every kid gets the support they need." svg_href_3="#svg-smile" title_3="Respect" content_3="Our teaching style is collaborative, respectful, teamwork-focused, and fun." %}
+      </div>
+    </section>
+
+    <!-- Free Programs -->
+    <section class="padding-vertical-3 bg-binary">
+      <div class="grid-container">
+        <div class="grid-x grid-padding-x">
+          <div class="cell medium-7">
+            <h2 class="title text-primary">Free coding programs for kids and teens.</h2>
+            <p>We All Code lessons teach STEM through experience. With one mentor for every two students, kids can build confidence and get the attention they need to thrive.</p>
+            <a href="{% url 'weallcode-programs' %}" class="button large">See All Programs</a>
+          </div>
+          <div class="cell medium-5">
+            <img class="width-100" src="{% static 'weallcode/images/photos/mentor-ratio.jpg' %}" alt="mentor and student">
+          </div>
         </div>
       </div>
-    </div>
-  </section>
+    </section>
 
-  <!-- Core Values -->
-  <section class="margin-bottom-3">
-    <div class="grid-container">
-      <div class="grid-x grid-padding-x">
-        <div class="small-6 small-offset-3">
-          <h2 class="title text-tertiary text-center">Core Values</h2>
-        </div>
-      </div>
+    <!-- Join Us -->
+    <section class="padding-vertical-3 bg-dark-blue">
+      <div class="grid-container">
+        <h3 class="title text-white text-center">Join Us</h3>
 
-      {% include "weallcode/snippets/posters.html" with svg_href_1="#svg-intellectual" title_1="Open Mind" content_1="We emphasize fast-paced, experiential learning in an engaging and iterative format." svg_href_2="#svg-respect" title_2="Support" content_2="Our close 2:1 student-to-mentor ratio ensures every kid gets the support they need." svg_href_3="#svg-smile" title_3="Respect" content_3="Our teaching style is collaborative, respectful, teamwork-focused, and fun." %}
-    </div>
-  </section>
+        <div class="grid-x grid-padding-x margin-vertical-3">
+          <!-- Cell -->
+          <div class="small-12 medium-6 large-4 cell margin-bottom-2">
+            <div class="bg-white radius">
+              <h6 class="text-uppercase padding-1 margin-0">Volunteers</h6>
+              <img class="width-100" src="{% static 'weallcode/images/photos/join-us-volunteer.jpg' %}" alt="">
+              <div class="padding-1 padding-horizontal-2 text-center">
+                <a class="button bg-gray-for-blue width-100 margin-top-1" href="{% url 'weallcode-join-us' %}#volunteer">Volunteer</a>
+              </div>
+            </div>
+          </div>
 
-  <!-- Free Programs -->
-  <section class="padding-vertical-3 bg-binary">
-    <div class="grid-container">
-      <div class="grid-x grid-padding-x">
-        <div class="cell medium-7">
-          <h2 class="title text-primary">Free coding programs for kids and teens.</h2>
-          <p>We All Code lessons teach STEM through experience. With one mentor for every two students, kids can build confidence and get the attention they need to thrive.</p>
-          <a href="{% url 'weallcode-programs' %}" class="button large">See All Programs</a>
-        </div>
-        <div class="cell medium-5">
-          <img class="width-100" src="{% static 'weallcode/images/photos/mentor-ratio.jpg' %}" alt="mentor and student">
-        </div>
-      </div>
-    </div>
-  </section>
+          <!-- Cell -->
+          <div class="small-12 medium-6 large-4 cell margin-bottom-2">
+            <div class="bg-white radius">
+              <h6 class="text-uppercase padding-1 margin-0">Donors</h6>
+              <img class="width-100" src="{% static 'weallcode/images/photos/join-us-donor.jpg' %}" alt="">
+              <div class="padding-1 padding-horizontal-2 text-center">
+                <a class="button bg-tertiary width-100 margin-top-1" href="{% url 'weallcode-join-us' %}#donate">Donate</a>
+              </div>
+            </div>
+          </div>
 
-  <!-- Join Us -->
-  <section class="padding-vertical-3 bg-dark-blue">
-    <div class="grid-container">
-      <h3 class="title text-white text-center">Join Us</h3>
-
-      <div class="grid-x grid-padding-x margin-vertical-3">
-        <!-- Cell -->
-        <div class="small-12 medium-6 large-4 cell margin-bottom-2">
-          <div class="bg-white radius">
-            <h6 class="text-uppercase padding-1 margin-0">Volunteers</h6>
-            <img class="width-100" src="{% static 'weallcode/images/photos/join-us-volunteer.jpg' %}" alt="">
-            <div class="padding-1 padding-horizontal-2 text-center">
-              <a class="button bg-gray-for-blue width-100 margin-top-1" href="{% url 'weallcode-join-us' %}#volunteer">Volunteer</a>
+          <!-- Cell -->
+          <div class="small-12 medium-6 large-4 cell margin-bottom-2">
+            <div class="bg-white radius">
+              <h6 class="text-uppercase padding-1 margin-0">Sponsors</h6>
+              <img class="width-100" src="{% static 'weallcode/images/photos/join-us-sponsor.jpg' %}" alt="">
+              <div class="padding-1 padding-horizontal-2 text-center">
+                <a class="button bg-primary width-100 margin-top-1" href="{% url 'weallcode-join-us' %}#sponsorship">Sponsor</a>
+              </div>
             </div>
           </div>
         </div>
 
-        <!-- Cell -->
-        <div class="small-12 medium-6 large-4 cell margin-bottom-2">
-          <div class="bg-white radius">
-            <h6 class="text-uppercase padding-1 margin-0">Donors</h6>
-            <img class="width-100" src="{% static 'weallcode/images/photos/join-us-donor.jpg' %}" alt="">
-            <div class="padding-1 padding-horizontal-2 text-center">
-              <a class="button bg-tertiary width-100 margin-top-1" href="{% url 'weallcode-join-us' %}#donate">Donate</a>
-            </div>
+        <div class="grid-x grid-padding-x">
+          <div class="cell small-4 medium-auto margin-bottom-2">
+            <img class="width-100" src="{% static 'weallcode/images/supporters/activecampaign.png' %}" alt="Active Campaign">
           </div>
-        </div>
-
-        <!-- Cell -->
-        <div class="small-12 medium-6 large-4 cell margin-bottom-2">
-          <div class="bg-white radius">
-            <h6 class="text-uppercase padding-1 margin-0">Sponsors</h6>
-            <img class="width-100" src="{% static 'weallcode/images/photos/join-us-sponsor.jpg' %}" alt="">
-            <div class="padding-1 padding-horizontal-2 text-center">
-              <a class="button bg-primary width-100 margin-top-1" href="{% url 'weallcode-join-us' %}#sponsorship">Sponsor</a>
-            </div>
+          <div class="cell small-4 medium-auto margin-bottom-2">
+            <img class="width-100" src="{% static 'weallcode/images/supporters/cme-group-foundation.png' %}" alt="CME Group Foundation">
+          </div>
+          <div class="cell small-4 medium-auto margin-bottom-2">
+            <img class="width-100" src="{% static 'weallcode/images/supporters/mind-hand.png' %}" alt="Mind+Hand">
+          </div>
+          <div class="cell small-4 medium-auto margin-bottom-2">
+            <img class="width-100" src="{% static 'weallcode/images/supporters/spothero.png' %}" alt="SpotHero">
+          </div>
+          <div class="cell small-4 medium-auto margin-bottom-2">
+            <img class="width-100" src="{% static 'weallcode/images/supporters/the-nerdery.png' %}" alt="Nerdery">
+          </div>
+          <div class="cell small-4 medium-auto margin-bottom-2">
+            <img class="width-100" src="{% static 'weallcode/images/supporters/west-town.png' %}" alt="West Town">
+          </div>
+          <div class="cell small-4 medium-auto margin-bottom-2">
+            <img class="width-100" src="{% static 'weallcode/images/supporters/wyzant.png' %}" alt="Wyzant">
           </div>
         </div>
       </div>
-
-      <div class="grid-x grid-padding-x">
-        <div class="cell small-4 medium-auto margin-bottom-2">
-          <img class="width-100" src="{% static 'weallcode/images/supporters/activecampaign.png' %}" alt="Active Campaign">
-        </div>
-        <div class="cell small-4 medium-auto margin-bottom-2">
-          <img class="width-100" src="{% static 'weallcode/images/supporters/cme-group-foundation.png' %}" alt="CME Group Foundation">
-        </div>
-        <div class="cell small-4 medium-auto margin-bottom-2">
-          <img class="width-100" src="{% static 'weallcode/images/supporters/mind-hand.png' %}" alt="Mind+Hand">
-        </div>
-        <div class="cell small-4 medium-auto margin-bottom-2">
-          <img class="width-100" src="{% static 'weallcode/images/supporters/spothero.png' %}" alt="SpotHero">
-        </div>
-        <div class="cell small-4 medium-auto margin-bottom-2">
-          <img class="width-100" src="{% static 'weallcode/images/supporters/the-nerdery.png' %}" alt="Nerdery">
-        </div>
-        <div class="cell small-4 medium-auto margin-bottom-2">
-          <img class="width-100" src="{% static 'weallcode/images/supporters/west-town.png' %}" alt="West Town">
-        </div>
-        <div class="cell small-4 medium-auto margin-bottom-2">
-          <img class="width-100" src="{% static 'weallcode/images/supporters/wyzant.png' %}" alt="Wyzant">
-        </div>
-      </div>
-    </div>
-  </section>
+    </section>
+  </main>
 {% endblock %}

--- a/weallcode/templates/weallcode/join_us.html
+++ b/weallcode/templates/weallcode/join_us.html
@@ -26,9 +26,9 @@
 
 {% block content %}
 
-  <main id="main">
-    {% include "weallcode/snippets/hero_image.html" with src="weallcode/images/photos/hero-join-us.jpg" alt="join us" %}
+  {% include "weallcode/snippets/hero_image.html" with src="weallcode/images/photos/hero-join-us.jpg" alt="join us" %}
 
+  <main id="main">
     <!-- Volunteer -->
     <section id="volunteer" class="padding-vertical-3">
       <div class="grid-container">

--- a/weallcode/templates/weallcode/join_us.html
+++ b/weallcode/templates/weallcode/join_us.html
@@ -26,171 +26,173 @@
 
 {% block content %}
 
-  {% include "weallcode/snippets/hero_image.html" with src="weallcode/images/photos/hero-join-us.jpg" alt="join us" %}
+  <main id="main">
+    {% include "weallcode/snippets/hero_image.html" with src="weallcode/images/photos/hero-join-us.jpg" alt="join us" %}
 
-  <!-- Volunteer -->
-  <section id="volunteer" class="padding-vertical-3">
-    <div class="grid-container">
-      <div class="grid-x">
-        <div class="cell large-8 padding-right-2">
-          <h1 class="title text-tertiary margin-bottom-2">Join Us</h1>
-          <p>We All Code wouldn't exist without your support! Our instructors, volunteers, and sponsors make it possible for kids to explore their curiosity through coding.</p>
-        </div>
-        <div class="cell large-4 position-relative">
-          <div class="aside-title">
-            <div>
-              <span class="text-tertiary display-inline-block">Educate the </span>
-              <span class="text-tertiary display-inline-block">technology </span>
-              <span class="text-secondary display-inline-block">leaders of </span>
-              <span class="text-white display-inline-block">tomorrow</span>
-            </div>
-            <div class="line width-25 bg-primary margin-top-1"></div>
+    <!-- Volunteer -->
+    <section id="volunteer" class="padding-vertical-3">
+      <div class="grid-container">
+        <div class="grid-x">
+          <div class="cell large-8 padding-right-2">
+            <h1 class="title text-tertiary margin-bottom-2">Join Us</h1>
+            <p>We All Code wouldn't exist without your support! Our instructors, volunteers, and sponsors make it possible for kids to explore their curiosity through coding.</p>
           </div>
-        </div>
-      </div>
-
-      <div class="grid-x grid-padding-x margin-vertical-3">
-        <div class="cell medium-6">
-          <div class="binary-drop-left">
-            <img class="width-100" src="{% static 'weallcode/images/photos/make-a-difference.jpg' %}" alt="Photo of student and mentor in class.">
-          </div>
-        </div>
-        <div class="cell medium-6">
-          <h3 class="title text-tertiary margin-vertical-2">Make a difference</h3>
-
-          <ul class="list-plus">
-            <li class="margin-vertical-1"><strong>Free classes</strong> are open to kids across Chicago</li>
-            <li class="margin-vertical-1"><strong>Highly-trained instructors and mentors</strong> teach coding skills</li>
-            <li class="margin-vertical-1">Students are encouraged to <strong>show what they know with real working projects</strong></li>
-            <li class="margin-vertical-1"><strong>Kids work collaboratively</strong>, respect their peers, and have fun</li>
-          </ul>
-        </div>
-      </div>
-
-      <div class="text-center">
-        <a class="button large" href="{% url 'account_signup' %}">Become a Volunteer</a>
-      </div>
-    </div>
-  </section>
-
-
-  <!-- Donate -->
-  <section id="donate" class="bg-binary padding-vertical-2">
-    <div class="grid-container">
-      <div class="grid-x margin-vertical-3">
-        <div class="cell medium-8 bg-white padding-2">
-          <h2 class="title text-primary">Donate to make a difference</h2>
-          <p><strong>Your generous financial support makes coding accessible to kids across Chicago.</strong> Every donation makes a difference!</p>
-
-          <p><a class="button large tertiary" href="javascript:donsPlus.openWidget();">Donate</a></p>
-        </div>
-        <div class="cell medium-4 bg-dark-blue text-white padding-2">
-          <div class="line bg-primary width-25 margin-bottom-3"></div>
-          <div class="text-huge text-uppercase text-bold line-height-1 margin-bottom-2">
-            <div class="text-tertiary">Money should</div>
-            <div class="text-tertiary">never be a barrier</div>
-            <div class="text-secondary">for kids</div>
-            <div>to learn code</div>
-          </div>
-          <p>Our classes are <strong>FREE</strong> whenever possible.</p>
-        </div>
-      </div>
-    </div>
-  </section>
-
-
-  <!-- Sponsorship -->
-  <section id="sponsorship" class="bg-dark-blue padding-vertical-3">
-    <div class="grid-container">
-      <div class="text-white text-center">
-        <h2 class="title">Sponsorship</h2>
-        <p class="medium-padding-horizontal-3">Help support us in our mission to <strong class="text-secondary">inspire, support, and teach kids STEM skills</strong> through corporate and organizational sponsorship. This can take many forms, and help provide even more opportunities to our kids. To get involved, email us at <a class="text-secondary" href="mailto:hello@weallcode.org">hello@weallcode.org</a>.</p>
-      </div>
-
-      <div class="margin-top-2 grid-x grid-margin-x grid-margin-y text-black">
-        <div class="cell medium-6 padding-1 bg-white">
-          <div class="grid-x">
-            <svg class="cell small-2 medium-3 padding-top-1 fill-tertiary program-icon">
-              <use xlink:href="#svg-parenting"></use>
-            </svg>
-            <div class="cell small-10 medium-9 padding-top-1 padding-left-2">
-              <h4 class="text-uppercase text-primary font-bold">Volunteer</h4>
-              <p><strong>Volunteer as individuals or a group</strong> to help with classes, programs, or events that benefit kids.</p>
+          <div class="cell large-4 position-relative">
+            <div class="aside-title">
+              <div>
+                <span class="text-tertiary display-inline-block">Educate the </span>
+                <span class="text-tertiary display-inline-block">technology </span>
+                <span class="text-secondary display-inline-block">leaders of </span>
+                <span class="text-white display-inline-block">tomorrow</span>
+              </div>
+              <div class="line width-25 bg-primary margin-top-1"></div>
             </div>
           </div>
         </div>
-        <div class="cell medium-6 padding-1 bg-white">
-          <div class="grid-x">
-            <svg class="cell small-2 medium-3 padding-top-1 fill-tertiary program-icon">
-              <use xlink:href="#svg-company"></use>
-            </svg>
-            <div class="cell small-10 medium-9 padding-top-1 padding-left-2">
-              <h4 class="text-uppercase text-primary font-bold">Locations</h4>
-              <p><strong>Provide locations for events or classes</strong> so kids around the city have access to education.</p>
-            </div>
-          </div>
-        </div>
-        <div class="cell medium-6 padding-1 bg-white">
-          <div class="grid-x">
-            <svg class="cell small-2 medium-3 padding-top-1 fill-tertiary program-icon">
-              <use xlink:href="#svg-design"></use>
-            </svg>
-            <div class="cell small-10 medium-9 padding-top-1 padding-left-2">
-              <h4 class="text-uppercase text-primary font-bold">Equipment</h4>
-              <p><strong>Donate equipment or other resources</strong> to expose more kids to different technologies.</p>
-            </div>
-          </div>
-        </div>
-        <div class="cell medium-6 padding-1 bg-white">
-          <div class="grid-x">
-            <svg class="cell small-2 medium-3 padding-top-1 fill-tertiary program-icon">
-              <use xlink:href="#svg-money"></use>
-            </svg>
-            <div class="cell small-10 medium-9 padding-top-1 padding-left-2">
-              <h4 class="text-uppercase text-primary font-bold">Financial</h4>
-              <p><strong>100% of funding</strong> goes towards equipment and food for youth, attendees, and mentors.</p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
 
-  {% include "weallcode/snippets/hero_image.html" with src="weallcode/images/backgrounds/map.png" alt="map" %}
-
-  <!-- Contact -->
-  <section id="contact" class="padding-vertical-3">
-    <div class="grid-container">
-      <div class="grid-x">
-        <div class="cell large-8 padding-right-2">
-          <h1 class="title text-tertiary margin-bottom-2">Contact Us</h1>
-          <p><strong class="text-secondary">No matter the reason for contacting us, we care about you</strong> and connecting you with the information you need to get involved or learn more about us and what we are doing. If you prefer to email us, feel free to reach out at <a href="mailto:hello@weallcode.org" class="text-secondary">hello@weallcode.org</a></p>
-        </div>
-        <div class="cell large-4 position-relative">
-          <div class="aside-title bg-primary text-white">
-            <div>Volunteer</div>
-            <div>Donate</div>
-            <div>Sponsor</div>
-            <div>Collaborate</div>
-            <div class="line width-25 bg-secondary margin-top-1"></div>
-          </div>
-        </div>
-      </div>
-
-      <form id="contact-form" method="POST" action="{% url 'weallcode-join-us' %}#contact-form">
-        {% csrf_token %}
         <div class="grid-x grid-padding-x margin-vertical-3">
-          {% if messages %}
-            <div class="cell">{% include 'weallcode/_messages.html' %}</div>
-          {% endif %}
-          {{ form.as_grid|safe }}
-          <div class="cell text-center">
-            <button type="submit" class="button padding-horizontal-3">Submit</button>
+          <div class="cell medium-6">
+            <div class="binary-drop-left">
+              <img class="width-100" src="{% static 'weallcode/images/photos/make-a-difference.jpg' %}" alt="Photo of student and mentor in class.">
+            </div>
+          </div>
+          <div class="cell medium-6">
+            <h3 class="title text-tertiary margin-vertical-2">Make a difference</h3>
+
+            <ul class="list-plus">
+              <li class="margin-vertical-1"><strong>Free classes</strong> are open to kids across Chicago</li>
+              <li class="margin-vertical-1"><strong>Highly-trained instructors and mentors</strong> teach coding skills</li>
+              <li class="margin-vertical-1">Students are encouraged to <strong>show what they know with real working projects</strong></li>
+              <li class="margin-vertical-1"><strong>Kids work collaboratively</strong>, respect their peers, and have fun</li>
+            </ul>
           </div>
         </div>
-      </form>
 
-    </div>
-  </section>
+        <div class="text-center">
+          <a class="button large" href="{% url 'account_signup' %}">Become a Volunteer</a>
+        </div>
+      </div>
+    </section>
+
+
+    <!-- Donate -->
+    <section id="donate" class="bg-binary padding-vertical-2">
+      <div class="grid-container">
+        <div class="grid-x margin-vertical-3">
+          <div class="cell medium-8 bg-white padding-2">
+            <h2 class="title text-primary">Donate to make a difference</h2>
+            <p><strong>Your generous financial support makes coding accessible to kids across Chicago.</strong> Every donation makes a difference!</p>
+
+            <p><a class="button large tertiary" href="javascript:donsPlus.openWidget();">Donate</a></p>
+          </div>
+          <div class="cell medium-4 bg-dark-blue text-white padding-2">
+            <div class="line bg-primary width-25 margin-bottom-3"></div>
+            <div class="text-huge text-uppercase text-bold line-height-1 margin-bottom-2">
+              <div class="text-tertiary">Money should</div>
+              <div class="text-tertiary">never be a barrier</div>
+              <div class="text-secondary">for kids</div>
+              <div>to learn code</div>
+            </div>
+            <p>Our classes are <strong>FREE</strong> whenever possible.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+
+    <!-- Sponsorship -->
+    <section id="sponsorship" class="bg-dark-blue padding-vertical-3">
+      <div class="grid-container">
+        <div class="text-white text-center">
+          <h2 class="title">Sponsorship</h2>
+          <p class="medium-padding-horizontal-3">Help support us in our mission to <strong class="text-secondary">inspire, support, and teach kids STEM skills</strong> through corporate and organizational sponsorship. This can take many forms, and help provide even more opportunities to our kids. To get involved, email us at <a class="text-secondary" href="mailto:hello@weallcode.org">hello@weallcode.org</a>.</p>
+        </div>
+
+        <div class="margin-top-2 grid-x grid-margin-x grid-margin-y text-black">
+          <div class="cell medium-6 padding-1 bg-white">
+            <div class="grid-x">
+              <svg class="cell small-2 medium-3 padding-top-1 fill-tertiary program-icon">
+                <use xlink:href="#svg-parenting"></use>
+              </svg>
+              <div class="cell small-10 medium-9 padding-top-1 padding-left-2">
+                <h4 class="text-uppercase text-primary font-bold">Volunteer</h4>
+                <p><strong>Volunteer as individuals or a group</strong> to help with classes, programs, or events that benefit kids.</p>
+              </div>
+            </div>
+          </div>
+          <div class="cell medium-6 padding-1 bg-white">
+            <div class="grid-x">
+              <svg class="cell small-2 medium-3 padding-top-1 fill-tertiary program-icon">
+                <use xlink:href="#svg-company"></use>
+              </svg>
+              <div class="cell small-10 medium-9 padding-top-1 padding-left-2">
+                <h4 class="text-uppercase text-primary font-bold">Locations</h4>
+                <p><strong>Provide locations for events or classes</strong> so kids around the city have access to education.</p>
+              </div>
+            </div>
+          </div>
+          <div class="cell medium-6 padding-1 bg-white">
+            <div class="grid-x">
+              <svg class="cell small-2 medium-3 padding-top-1 fill-tertiary program-icon">
+                <use xlink:href="#svg-design"></use>
+              </svg>
+              <div class="cell small-10 medium-9 padding-top-1 padding-left-2">
+                <h4 class="text-uppercase text-primary font-bold">Equipment</h4>
+                <p><strong>Donate equipment or other resources</strong> to expose more kids to different technologies.</p>
+              </div>
+            </div>
+          </div>
+          <div class="cell medium-6 padding-1 bg-white">
+            <div class="grid-x">
+              <svg class="cell small-2 medium-3 padding-top-1 fill-tertiary program-icon">
+                <use xlink:href="#svg-money"></use>
+              </svg>
+              <div class="cell small-10 medium-9 padding-top-1 padding-left-2">
+                <h4 class="text-uppercase text-primary font-bold">Financial</h4>
+                <p><strong>100% of funding</strong> goes towards equipment and food for youth, attendees, and mentors.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    {% include "weallcode/snippets/hero_image.html" with src="weallcode/images/backgrounds/map.png" alt="map" %}
+
+    <!-- Contact -->
+    <section id="contact" class="padding-vertical-3">
+      <div class="grid-container">
+        <div class="grid-x">
+          <div class="cell large-8 padding-right-2">
+            <h1 class="title text-tertiary margin-bottom-2">Contact Us</h1>
+            <p><strong class="text-secondary">No matter the reason for contacting us, we care about you</strong> and connecting you with the information you need to get involved or learn more about us and what we are doing. If you prefer to email us, feel free to reach out at <a href="mailto:hello@weallcode.org" class="text-secondary">hello@weallcode.org</a></p>
+          </div>
+          <div class="cell large-4 position-relative">
+            <div class="aside-title bg-primary text-white">
+              <div>Volunteer</div>
+              <div>Donate</div>
+              <div>Sponsor</div>
+              <div>Collaborate</div>
+              <div class="line width-25 bg-secondary margin-top-1"></div>
+            </div>
+          </div>
+        </div>
+
+        <form id="contact-form" method="POST" action="{% url 'weallcode-join-us' %}#contact-form">
+          {% csrf_token %}
+          <div class="grid-x grid-padding-x margin-vertical-3">
+            {% if messages %}
+              <div class="cell">{% include 'weallcode/_messages.html' %}</div>
+            {% endif %}
+            {{ form.as_grid|safe }}
+            <div class="cell text-center">
+              <button type="submit" class="button padding-horizontal-3">Submit</button>
+            </div>
+          </div>
+        </form>
+
+      </div>
+    </section>
+  </main>
 
 {% endblock %}

--- a/weallcode/templates/weallcode/our_story.html
+++ b/weallcode/templates/weallcode/our_story.html
@@ -19,9 +19,9 @@
 {% endblock subheader %}
 
 {% block content %}
-  <main id="main">
-    {% include "weallcode/snippets/hero_image.html" with src="weallcode/images/photos/hero-our-story.jpg" alt="our story" %}
+  {% include "weallcode/snippets/hero_image.html" with src="weallcode/images/photos/hero-our-story.jpg" alt="our story" %}
 
+  <main id="main">
     <!-- Vision -->
     <section id="vision" class="padding-vertical-3">
       <div class="grid-container">

--- a/weallcode/templates/weallcode/our_story.html
+++ b/weallcode/templates/weallcode/our_story.html
@@ -19,295 +19,297 @@
 {% endblock subheader %}
 
 {% block content %}
-  {% include "weallcode/snippets/hero_image.html" with src="weallcode/images/photos/hero-our-story.jpg" alt="our story" %}
+  <main id="main">
+    {% include "weallcode/snippets/hero_image.html" with src="weallcode/images/photos/hero-our-story.jpg" alt="our story" %}
 
-  <!-- Vision -->
-  <section id="vision" class="padding-vertical-3">
-    <div class="grid-container">
-      <div class="grid-x">
-        <div class="cell large-8 padding-right-2">
-          <h1 class="title text-tertiary margin-bottom-2">About us</h1>
-          <p>We All Code was founded in 2013 as CoderDojoChi. Our founder, Ali Karbassi, built We All Code from the ground up in an effort to eliminate the barriers keeping girls and underserved youth from learning STEM skills.</p>
-        </div>
-        <div class="cell large-4 position-relative">
-        <div class="aside-title">
-            <div>
-              <span class="text-tertiary display-inline-block">Eliminating </span>
-              <span class="text-tertiary display-inline-block">barriers </span>
-              <span class="text-secondary display-inline-block">for all kids </span>
-              <span class="text-white display-inline-block">learning code</span>
+    <!-- Vision -->
+    <section id="vision" class="padding-vertical-3">
+      <div class="grid-container">
+        <div class="grid-x">
+          <div class="cell large-8 padding-right-2">
+            <h1 class="title text-tertiary margin-bottom-2">About us</h1>
+            <p>We All Code was founded in 2013 as CoderDojoChi. Our founder, Ali Karbassi, built We All Code from the ground up in an effort to eliminate the barriers keeping girls and underserved youth from learning STEM skills.</p>
+          </div>
+          <div class="cell large-4 position-relative">
+          <div class="aside-title">
+              <div>
+                <span class="text-tertiary display-inline-block">Eliminating </span>
+                <span class="text-tertiary display-inline-block">barriers </span>
+                <span class="text-secondary display-inline-block">for all kids </span>
+                <span class="text-white display-inline-block">learning code</span>
+              </div>
+              <div class="line width-25 bg-primary margin-top-1"></div>
             </div>
-            <div class="line width-25 bg-primary margin-top-1"></div>
+          </div>
+        </div>
+
+        <div class="grid-x grid-padding-x margin-vertical-3">
+          <div class="cell medium-6">
+            <div class="binary-drop-left">
+              <img class="width-100" src="{% static 'weallcode/images/photos/benefits.jpg' %}" alt="after class photo">
+            </div>
+          </div>
+          <div class="cell medium-6">
+            <h3 class="title text-tertiary margin-vertical-2">Benefits</h3>
+
+            <ul class="list-plus">
+              <li class="margin-vertical-1"><strong>Free classes</strong> are open to kids across Chicago</li>
+              <li class="margin-vertical-1"><strong>Highly-trained instructors and mentors</strong> teach coding skills</li>
+              <li class="margin-vertical-1">Students are encouraged to <strong>show what they know with real working projects</strong></li>
+              <li class="margin-vertical-1"><strong>Kids work collaboratively</strong>, respect their peers, and have fun</li>
+            </ul>
           </div>
         </div>
       </div>
+    </section>
 
-      <div class="grid-x grid-padding-x margin-vertical-3">
-        <div class="cell medium-6">
-          <div class="binary-drop-left">
-            <img class="width-100" src="{% static 'weallcode/images/photos/benefits.jpg' %}" alt="after class photo">
-          </div>
-        </div>
-        <div class="cell medium-6">
-          <h3 class="title text-tertiary margin-vertical-2">Benefits</h3>
+    <!-- Mission -->
+    <section id="mission" class="bg-dark-blue text-white padding-vertical-3">
+      <div class="grid-container">
+        <h2 class="title margin-bottom-2 text-center">Mission</h2>
 
-          <ul class="list-plus">
-            <li class="margin-vertical-1"><strong>Free classes</strong> are open to kids across Chicago</li>
-            <li class="margin-vertical-1"><strong>Highly-trained instructors and mentors</strong> teach coding skills</li>
-            <li class="margin-vertical-1">Students are encouraged to <strong>show what they know with real working projects</strong></li>
-            <li class="margin-vertical-1"><strong>Kids work collaboratively</strong>, respect their peers, and have fun</li>
-          </ul>
-        </div>
-      </div>
-    </div>
-  </section>
+        <p>We All Code exists because <strong class="text-secondary">we believe every kid deserves to excel</strong> in one of the emerging fields of STEM, whether they choose to pursue more education or go straight into careers in computer science. Our mission is to <strong class="text-secondary">inspire, support, and teach</strong> these skills to help them be successful.</p>
 
-  <!-- Mission -->
-  <section id="mission" class="bg-dark-blue text-white padding-vertical-3">
-    <div class="grid-container">
-      <h2 class="title margin-bottom-2 text-center">Mission</h2>
-
-      <p>We All Code exists because <strong class="text-secondary">we believe every kid deserves to excel</strong> in one of the emerging fields of STEM, whether they choose to pursue more education or go straight into careers in computer science. Our mission is to <strong class="text-secondary">inspire, support, and teach</strong> these skills to help them be successful.</p>
-
-      <div class="margin-top-2 grid-x grid-margin-x grid-margin-y text-black">
-        <div class="cell medium-6 padding-1 bg-white">
-          <div class="grid-x">
-            <svg class="cell small-2 medium-3 padding-top-1 fill-tertiary program-icon">
-              <use xlink:href="#svg-budget"></use>
-            </svg>
-            <div class="cell small-10 medium-9 padding-top-1 padding-left-2">
-              <h4 class="text-uppercase text-primary font-bold">Prosperity</h4>
-              <p>STEM fields <strong>out-earn all other fields by 12-30%</strong>.</p>
+        <div class="margin-top-2 grid-x grid-margin-x grid-margin-y text-black">
+          <div class="cell medium-6 padding-1 bg-white">
+            <div class="grid-x">
+              <svg class="cell small-2 medium-3 padding-top-1 fill-tertiary program-icon">
+                <use xlink:href="#svg-budget"></use>
+              </svg>
+              <div class="cell small-10 medium-9 padding-top-1 padding-left-2">
+                <h4 class="text-uppercase text-primary font-bold">Prosperity</h4>
+                <p>STEM fields <strong>out-earn all other fields by 12-30%</strong>.</p>
+              </div>
             </div>
           </div>
-        </div>
-        <div class="cell medium-6 padding-1 bg-white">
-          <div class="grid-x">
-            <svg class="cell small-2 medium-3 padding-top-1 fill-tertiary program-icon">
-              <use xlink:href="#svg-parenting"></use>
-            </svg>
-            <div class="cell small-10 medium-9 padding-top-1 padding-left-2">
-              <h4 class="text-uppercase text-primary font-bold">Gender Equality</h4>
-              <p><strong>Women only make up 28% of the workforce</strong> in the fields of science and engineering.</p>
+          <div class="cell medium-6 padding-1 bg-white">
+            <div class="grid-x">
+              <svg class="cell small-2 medium-3 padding-top-1 fill-tertiary program-icon">
+                <use xlink:href="#svg-parenting"></use>
+              </svg>
+              <div class="cell small-10 medium-9 padding-top-1 padding-left-2">
+                <h4 class="text-uppercase text-primary font-bold">Gender Equality</h4>
+                <p><strong>Women only make up 28% of the workforce</strong> in the fields of science and engineering.</p>
+              </div>
             </div>
           </div>
-        </div>
-        <div class="cell medium-6 padding-1 bg-white">
-          <div class="grid-x">
-            <svg class="cell small-2 medium-3 padding-top-1 fill-tertiary program-icon">
-              <use xlink:href="#svg-success"></use>
-            </svg>
-            <div class="cell small-10 medium-9 padding-top-1 padding-left-2">
-              <h4 class="text-uppercase text-primary font-bold">Ethnic Diversity</h4>
-              <p><strong>Latinx, African Americans, and Native Americans average 2.7%</strong> of the STEM degrees earned.</p>
+          <div class="cell medium-6 padding-1 bg-white">
+            <div class="grid-x">
+              <svg class="cell small-2 medium-3 padding-top-1 fill-tertiary program-icon">
+                <use xlink:href="#svg-success"></use>
+              </svg>
+              <div class="cell small-10 medium-9 padding-top-1 padding-left-2">
+                <h4 class="text-uppercase text-primary font-bold">Ethnic Diversity</h4>
+                <p><strong>Latinx, African Americans, and Native Americans average 2.7%</strong> of the STEM degrees earned.</p>
+              </div>
             </div>
           </div>
-        </div>
-        <div class="cell medium-6 padding-1 bg-white">
-          <div class="grid-x">
-            <svg class="cell small-2 medium-3 padding-top-1 fill-tertiary program-icon">
-              <use xlink:href="#svg-growth"></use>
-            </svg>
-            <div class="cell small-10 medium-9 padding-top-1 padding-left-2">
-              <h4 class="text-uppercase text-primary font-bold">Opportunity</h4>
-              <p><strong>STEM-related jobs grew three times</strong> the rate of non-STEM jobs between 2000 and 2010.</p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- Offerings -->
-  <section id="offerings" class="padding-vertical-3">
-    <div class="grid-container">
-      <div class="grid-x grid-padding-x">
-        <div class="cell medium-6">
-          <h2 class="title text-tertiary margin-bottom-2">What we offer</h2>
-          <p>We All Code offers <strong>classes, courses, and camps at every level</strong> to help kids get excited about coding.</p>
-          <p>Our lessons are fast-paced, experiential, and <strong>build the confidence kids need</strong> to put their skills to use.</p>
-          <p>Students <strong>learn from highly-trained instructors</strong> and benefit from the support of volunteer mentors. Our <strong>2 students to 1 mentor ratio</strong> means all kids get the attention they need to thrive.</p>
-        </div>
-        <div class="cell medium-5 medium-offset-1">
-          <div class="binary-drop-right">
-            <img class="width-100" src="{% static 'weallcode/images/photos/offerings.jpg' %}" alt="two students">
-          </div>
-        </div>
-      </div>
-
-      <div class="grid-x grid-margin-x grid-margin-y margin-top-2 text-white text-center">
-        <div class="cell padding-2 large-4 bg-gray-for-blue padding-vertical-3">
-          <div class="grid-x grid-margin-x grid-margin-y">
-            <svg class="cell medium-2 large-12 fill-white program-icon">
-              <use xlink:href="#svg-classes"></use>
-            </svg>
-            <div class="cell medium-10 large-12 medium-text-left large-text-center">
-              <h4 class="text-uppercase padding-top-1">Classes</h4>
-              <p>Classes are the foundation of We All Code's programming. During these 3-to-5 hour weekend sessions, kids learn about one specific coding topic, like HTML, at a particular level. </p>
-            </div>
-          </div>
-        </div>
-        <div class="cell padding-2 large-4 bg-tertiary padding-vertical-3">
-          <div class="grid-x grid-margin-x grid-margin-y">
-            <svg class="cell medium-2 large-12 fill-white program-icon">
-              <use xlink:href="#svg-courses"></use>
-            </svg>
-            <div class="cell medium-10 large-12 medium-text-left large-text-center">
-              <h4 class="text-uppercase padding-top-1">Courses</h4>
-              <p>Courses combine 3 classes to help kids build proficiency in HTML, CSS, JavaScript, and Python over the course of several weeks.</p>
-            </div>
-          </div>
-        </div>
-        <div class="cell padding-2 large-4 bg-primary padding-vertical-3">
-          <div class="grid-x grid-margin-x grid-margin-y">
-            <svg class="cell medium-2 large-12 fill-white program-icon">
-              <use xlink:href="#svg-camps"></use>
-            </svg>
-            <div class="cell medium-10 large-12 medium-text-left large-text-center">
-              <h4 class="text-uppercase padding-top-1">Camps</h4>
-              <p>Week-long summer experiences offering students the chance to learn in-depth skills like project management, quality assurance, and social skills along with code.</p>
+          <div class="cell medium-6 padding-1 bg-white">
+            <div class="grid-x">
+              <svg class="cell small-2 medium-3 padding-top-1 fill-tertiary program-icon">
+                <use xlink:href="#svg-growth"></use>
+              </svg>
+              <div class="cell small-10 medium-9 padding-top-1 padding-left-2">
+                <h4 class="text-uppercase text-primary font-bold">Opportunity</h4>
+                <p><strong>STEM-related jobs grew three times</strong> the rate of non-STEM jobs between 2000 and 2010.</p>
+              </div>
             </div>
           </div>
         </div>
       </div>
+    </section>
 
-      <p class="text-center margin-top-3">
-        <a class="button tertiary" href="{% url 'weallcode-programs' %}">See All Programs</a>
-      </p>
-    </div>
-  </section>
-
-
-  <section class="bg-binary padding-vertical-2 bg-gray-for-white">
-    <div class="grid-container">
-      <div class="grid-x margin-vertical-3">
-        <div class="cell medium-6 bg-white padding-2">
-          <h2 class="title text-tertiary">Ages 7 to 17</h2>
-          <p><strong>We All Code is open to all kids ages 7 to 17 with a focus toward kids from underserved areas.</strong> That means girls and boys from every neighborhood are welcome.</p>
-
-          <h5 class="title text-tertiary margin-top-2">We also welcome</h5>
-          <ul class="list-plus">
-            <li><strong>Parents</strong> who want to take part alongside their kids</li>
-            <li><strong>Volunteers</strong> from every field (not just developers!)</li>
-            <li><strong>Donors</strong> who want to make a difference in the future of STEM learning</li>
-          </ul>
-        </div>
-        <div class="cell medium-6 bg-dark-blue text-white padding-2">
-          <div class="line bg-primary width-25 margin-bottom-3"></div>
-          <div class="text-huge text-uppercase text-bold line-height-1 margin-bottom-2">
-            <div class="text-tertiary">Money should</div>
-            <div class="text-tertiary">never be a barrier</div>
-            <div class="text-secondary">for kids</div>
-            <div>to learn code</div>
+    <!-- Offerings -->
+    <section id="offerings" class="padding-vertical-3">
+      <div class="grid-container">
+        <div class="grid-x grid-padding-x">
+          <div class="cell medium-6">
+            <h2 class="title text-tertiary margin-bottom-2">What we offer</h2>
+            <p>We All Code offers <strong>classes, courses, and camps at every level</strong> to help kids get excited about coding.</p>
+            <p>Our lessons are fast-paced, experiential, and <strong>build the confidence kids need</strong> to put their skills to use.</p>
+            <p>Students <strong>learn from highly-trained instructors</strong> and benefit from the support of volunteer mentors. Our <strong>2 students to 1 mentor ratio</strong> means all kids get the attention they need to thrive.</p>
           </div>
-          <p>Our classes are <strong>FREE</strong> whenever possible.</p>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- Approach -->
-  <section id="approach" class="padding-vertical-3">
-    <div class="grid-container">
-      <div class="text-center">
-        <h2 class="title text-tertiary margin-bottom-2">Our Approach</h2>
-
-        <div>
-          <p><strong>We All Code teaches real, solid coding skills as a basis for a future in STEM.</strong></p>
-          <p>Highly-trained instructors guide our classes while mentors work closely with students. </p>
-          <p><strong>Kids get excited about coding</strong> when we make it relevant and encourage them to show what they know, solve problems, and explore possibilities.</p>
-        </div>
-      </div>
-
-      <div class="grid-x grid-margin-x grid-margin-y margin-top-2 text-white text-center">
-        <div class="cell padding-2 large-4 bg-gray-for-blue padding-vertical-3">
-          <div class="grid-x grid-margin-x grid-margin-y">
-            <svg class="cell medium-2 large-12 fill-white program-icon">
-              <use xlink:href="#svg-i-do"></use>
-            </svg>
-            <div class="cell medium-10 large-12 medium-text-left large-text-center">
-              <h4 class="text-uppercase padding-top-1">I Do</h4>
-              <p>Instructors demonstrates a skill to the students</p>
+          <div class="cell medium-5 medium-offset-1">
+            <div class="binary-drop-right">
+              <img class="width-100" src="{% static 'weallcode/images/photos/offerings.jpg' %}" alt="two students">
             </div>
           </div>
         </div>
-        <div class="cell padding-2 large-4 bg-tertiary padding-vertical-3">
-          <div class="grid-x grid-margin-x grid-margin-y">
-            <svg class="cell medium-2 large-12 fill-white program-icon">
-              <use xlink:href="#svg-we-do"></use>
-            </svg>
-            <div class="cell medium-10 large-12 medium-text-left large-text-center">
-              <h4 class="text-uppercase padding-top-1">We Do</h4>
-              <p>Students and instructors practice the skill together</p>
+
+        <div class="grid-x grid-margin-x grid-margin-y margin-top-2 text-white text-center">
+          <div class="cell padding-2 large-4 bg-gray-for-blue padding-vertical-3">
+            <div class="grid-x grid-margin-x grid-margin-y">
+              <svg class="cell medium-2 large-12 fill-white program-icon">
+                <use xlink:href="#svg-classes"></use>
+              </svg>
+              <div class="cell medium-10 large-12 medium-text-left large-text-center">
+                <h4 class="text-uppercase padding-top-1">Classes</h4>
+                <p>Classes are the foundation of We All Code's programming. During these 3-to-5 hour weekend sessions, kids learn about one specific coding topic, like HTML, at a particular level. </p>
+              </div>
+            </div>
+          </div>
+          <div class="cell padding-2 large-4 bg-tertiary padding-vertical-3">
+            <div class="grid-x grid-margin-x grid-margin-y">
+              <svg class="cell medium-2 large-12 fill-white program-icon">
+                <use xlink:href="#svg-courses"></use>
+              </svg>
+              <div class="cell medium-10 large-12 medium-text-left large-text-center">
+                <h4 class="text-uppercase padding-top-1">Courses</h4>
+                <p>Courses combine 3 classes to help kids build proficiency in HTML, CSS, JavaScript, and Python over the course of several weeks.</p>
+              </div>
+            </div>
+          </div>
+          <div class="cell padding-2 large-4 bg-primary padding-vertical-3">
+            <div class="grid-x grid-margin-x grid-margin-y">
+              <svg class="cell medium-2 large-12 fill-white program-icon">
+                <use xlink:href="#svg-camps"></use>
+              </svg>
+              <div class="cell medium-10 large-12 medium-text-left large-text-center">
+                <h4 class="text-uppercase padding-top-1">Camps</h4>
+                <p>Week-long summer experiences offering students the chance to learn in-depth skills like project management, quality assurance, and social skills along with code.</p>
+              </div>
             </div>
           </div>
         </div>
-        <div class="cell padding-2 large-4 bg-primary padding-vertical-3">
-          <div class="grid-x grid-margin-x grid-margin-y">
-            <svg class="cell medium-2 large-12 fill-white program-icon">
-              <use xlink:href="#svg-you-do"></use>
-            </svg>
-            <div class="cell medium-10 large-12 medium-text-left large-text-center">
-              <h4 class="text-uppercase padding-top-1">You Do</h4>
-              <p>Students show what they know by applying the skill</p>
+
+        <p class="text-center margin-top-3">
+          <a class="button tertiary" href="{% url 'weallcode-programs' %}">See All Programs</a>
+        </p>
+      </div>
+    </section>
+
+
+    <section class="bg-binary padding-vertical-2 bg-gray-for-white">
+      <div class="grid-container">
+        <div class="grid-x margin-vertical-3">
+          <div class="cell medium-6 bg-white padding-2">
+            <h2 class="title text-tertiary">Ages 7 to 17</h2>
+            <p><strong>We All Code is open to all kids ages 7 to 17 with a focus toward kids from underserved areas.</strong> That means girls and boys from every neighborhood are welcome.</p>
+
+            <h5 class="title text-tertiary margin-top-2">We also welcome</h5>
+            <ul class="list-plus">
+              <li><strong>Parents</strong> who want to take part alongside their kids</li>
+              <li><strong>Volunteers</strong> from every field (not just developers!)</li>
+              <li><strong>Donors</strong> who want to make a difference in the future of STEM learning</li>
+            </ul>
+          </div>
+          <div class="cell medium-6 bg-dark-blue text-white padding-2">
+            <div class="line bg-primary width-25 margin-bottom-3"></div>
+            <div class="text-huge text-uppercase text-bold line-height-1 margin-bottom-2">
+              <div class="text-tertiary">Money should</div>
+              <div class="text-tertiary">never be a barrier</div>
+              <div class="text-secondary">for kids</div>
+              <div>to learn code</div>
+            </div>
+            <p>Our classes are <strong>FREE</strong> whenever possible.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Approach -->
+    <section id="approach" class="padding-vertical-3">
+      <div class="grid-container">
+        <div class="text-center">
+          <h2 class="title text-tertiary margin-bottom-2">Our Approach</h2>
+
+          <div>
+            <p><strong>We All Code teaches real, solid coding skills as a basis for a future in STEM.</strong></p>
+            <p>Highly-trained instructors guide our classes while mentors work closely with students. </p>
+            <p><strong>Kids get excited about coding</strong> when we make it relevant and encourage them to show what they know, solve problems, and explore possibilities.</p>
+          </div>
+        </div>
+
+        <div class="grid-x grid-margin-x grid-margin-y margin-top-2 text-white text-center">
+          <div class="cell padding-2 large-4 bg-gray-for-blue padding-vertical-3">
+            <div class="grid-x grid-margin-x grid-margin-y">
+              <svg class="cell medium-2 large-12 fill-white program-icon">
+                <use xlink:href="#svg-i-do"></use>
+              </svg>
+              <div class="cell medium-10 large-12 medium-text-left large-text-center">
+                <h4 class="text-uppercase padding-top-1">I Do</h4>
+                <p>Instructors demonstrates a skill to the students</p>
+              </div>
+            </div>
+          </div>
+          <div class="cell padding-2 large-4 bg-tertiary padding-vertical-3">
+            <div class="grid-x grid-margin-x grid-margin-y">
+              <svg class="cell medium-2 large-12 fill-white program-icon">
+                <use xlink:href="#svg-we-do"></use>
+              </svg>
+              <div class="cell medium-10 large-12 medium-text-left large-text-center">
+                <h4 class="text-uppercase padding-top-1">We Do</h4>
+                <p>Students and instructors practice the skill together</p>
+              </div>
+            </div>
+          </div>
+          <div class="cell padding-2 large-4 bg-primary padding-vertical-3">
+            <div class="grid-x grid-margin-x grid-margin-y">
+              <svg class="cell medium-2 large-12 fill-white program-icon">
+                <use xlink:href="#svg-you-do"></use>
+              </svg>
+              <div class="cell medium-10 large-12 medium-text-left large-text-center">
+                <h4 class="text-uppercase padding-top-1">You Do</h4>
+                <p>Students show what they know by applying the skill</p>
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
-  </section>
+    </section>
 
-  <!-- Results -->
-  <section id="results" class="bg-dark-blue text-white padding-vertical-3">
-    <div class="grid-container">
-      <h2 class="title margin-bottom-2 text-center">The Results</h2>
+    <!-- Results -->
+    <section id="results" class="bg-dark-blue text-white padding-vertical-3">
+      <div class="grid-container">
+        <h2 class="title margin-bottom-2 text-center">The Results</h2>
 
-      <p class=" text-center">
-        We All Code fosters a supportive community centered around the betterment of its students and
-        their communities through education and outreach. But you don't have to take our word for it; <br>
-        <strong class="text-secondary">hear directly from our students, volunteers, and sponsors.</strong>
-      </p>
+        <p class=" text-center">
+          We All Code fosters a supportive community centered around the betterment of its students and
+          their communities through education and outreach. But you don't have to take our word for it; <br>
+          <strong class="text-secondary">hear directly from our students, volunteers, and sponsors.</strong>
+        </p>
 
-      <div class="text-uppercase">
-        <div class="grid-x margin-top-3 text-center">
-          <div class="cell medium-4 large-3 padding-bottom-2 medium-text-right">
-            <div class="text-white text-gigantic"><strong>42%</strong></div>
-            <div class="text-secondary">of students</div>
-            <div class="text-secondary">are female</div>
-            <div class="line bg-secondary width-25 margin-top-2 align-right large-show"></div>
+        <div class="text-uppercase">
+          <div class="grid-x margin-top-3 text-center">
+            <div class="cell medium-4 large-3 padding-bottom-2 medium-text-right">
+              <div class="text-white text-gigantic"><strong>42%</strong></div>
+              <div class="text-secondary">of students</div>
+              <div class="text-secondary">are female</div>
+              <div class="line bg-secondary width-25 margin-top-2 align-right large-show"></div>
+            </div>
+            <div class="cell medium-7 medium-offset-1">
+              <img class="width-100" src="{% static 'weallcode/images/photos/results-students.jpg' %}" alt="student">
+            </div>
           </div>
-          <div class="cell medium-7 medium-offset-1">
-            <img class="width-100" src="{% static 'weallcode/images/photos/results-students.jpg' %}" alt="student">
+
+          <div class="grid-x margin-top-3 text-center">
+            <div class="cell medium-4 large-3 padding-bottom-2 medium-text-right">
+              <div class="text-white text-gigantic"><strong>170</strong></div>
+              <div class="text-tertiary">mentors</div>
+              <div class="text-tertiary">volunteer</div>
+              <div class="text-tertiary">per year</div>
+              <div class="line bg-tertiary width-25 margin-top-2 align-right large-show"></div>
+            </div>
+            <div class="cell medium-7 medium-offset-1">
+              <img class="width-100" src="{% static 'weallcode/images/photos/results-volunteers.jpg' %}" alt="volunteers">
+            </div>
           </div>
+
+          <div class="grid-x margin-top-3 text-center">
+            <div class="cell medium-4 large-3 padding-bottom-2 medium-text-right">
+              <div class="text-white text-gigantic"><strong>20+</strong></div>
+              <div class="text-primary">sponsors</div>
+              <div class="text-primary">have hosted</div>
+              <div class="text-primary">a class</div>
+              <div class="line bg-primary width-25 margin-top-2 align-right large-show"></div>
+            </div>
+            <div class="cell medium-7 medium-offset-1">
+              <img class="width-100" src="{% static 'weallcode/images/photos/results-donors.jpg' %}" alt="donors">
+            </div>
+          </div>
+
         </div>
-
-        <div class="grid-x margin-top-3 text-center">
-          <div class="cell medium-4 large-3 padding-bottom-2 medium-text-right">
-            <div class="text-white text-gigantic"><strong>170</strong></div>
-            <div class="text-tertiary">mentors</div>
-            <div class="text-tertiary">volunteer</div>
-            <div class="text-tertiary">per year</div>
-            <div class="line bg-tertiary width-25 margin-top-2 align-right large-show"></div>
-          </div>
-          <div class="cell medium-7 medium-offset-1">
-            <img class="width-100" src="{% static 'weallcode/images/photos/results-volunteers.jpg' %}" alt="volunteers">
-          </div>
-        </div>
-
-        <div class="grid-x margin-top-3 text-center">
-          <div class="cell medium-4 large-3 padding-bottom-2 medium-text-right">
-            <div class="text-white text-gigantic"><strong>20+</strong></div>
-            <div class="text-primary">sponsors</div>
-            <div class="text-primary">have hosted</div>
-            <div class="text-primary">a class</div>
-            <div class="line bg-primary width-25 margin-top-2 align-right large-show"></div>
-          </div>
-          <div class="cell medium-7 medium-offset-1">
-            <img class="width-100" src="{% static 'weallcode/images/photos/results-donors.jpg' %}" alt="donors">
-          </div>
-        </div>
-
       </div>
-    </div>
-  </section>
+    </section>
+  </main>
 {% endblock %}

--- a/weallcode/templates/weallcode/privacy.html
+++ b/weallcode/templates/weallcode/privacy.html
@@ -3,84 +3,86 @@
 {% load static %}
 
 {% block content %}
-  <section class="bg-light-gray">
-    <div class="grid-container padding-vertical-3">
-      <h2 class="title text-tertiary">Concent &amp; Release</h2>
-      <p>In consideration of the acceptance of my application for the programs provided, I hereby waive, release, and discharge any and all claims for damages for personal injury, property damages or which may hereafter occur to me as a result of participation in said event. This release is intended to discharge in advance We All Code, its officials, officers, employees, volunteers and agents from liability, even though that liability may arise out of perceived negligence on the part of persons mentioned above. It is understood that some recreational activities involve an element of risk or danger of accidents, and knowing those risks, I hereby assume those risks. It is further understood and agreed that this waiver, release and assumption of risk is to be binding on my heirs and assignees.</p>
-    </div>
-  </section>
+  <main id="main">
+    <section class="bg-light-gray">
+      <div class="grid-container padding-vertical-3">
+        <h2 class="title text-tertiary">Concent &amp; Release</h2>
+        <p>In consideration of the acceptance of my application for the programs provided, I hereby waive, release, and discharge any and all claims for damages for personal injury, property damages or which may hereafter occur to me as a result of participation in said event. This release is intended to discharge in advance We All Code, its officials, officers, employees, volunteers and agents from liability, even though that liability may arise out of perceived negligence on the part of persons mentioned above. It is understood that some recreational activities involve an element of risk or danger of accidents, and knowing those risks, I hereby assume those risks. It is further understood and agreed that this waiver, release and assumption of risk is to be binding on my heirs and assignees.</p>
+      </div>
+    </section>
 
-  <section class="margin-vertical-3">
-    <div class="grid-container">
-      <h2 class="title text-tertiary">Privacy &amp; Terms</h2>
-      <h3 class="title">Web Site Terms and Conditions of Use</h3>
+    <section class="margin-vertical-3">
+      <div class="grid-container">
+        <h2 class="title text-tertiary">Privacy &amp; Terms</h2>
+        <h3 class="title">Web Site Terms and Conditions of Use</h3>
 
-      <h4 class="title">1. Terms</h4>
+        <h4 class="title">1. Terms</h4>
 
-      <p>By accessing this web site, you are agreeing to be bound by these web site Terms and Conditions of Use, all applicable laws and regulations, and agree that you are responsible for compliance with any applicable local laws. If you do not agree with any of these terms, you are prohibited from using or accessing this site. The materials contained in this web site are protected by applicable copyright and trade mark law.</p>
+        <p>By accessing this web site, you are agreeing to be bound by these web site Terms and Conditions of Use, all applicable laws and regulations, and agree that you are responsible for compliance with any applicable local laws. If you do not agree with any of these terms, you are prohibited from using or accessing this site. The materials contained in this web site are protected by applicable copyright and trade mark law.</p>
 
-      <h4 class="title">2. Use License</h4>
+        <h4 class="title">2. Use License</h4>
 
-      <ol type="a">
-        <li>
-          Permission is granted to temporarily download one copy of the materials (information or software) on We All Code's web site for personal, non-commercial transitory viewing only. This is the grant of a license, not a transfer of title, and under this license you may not:
+        <ol type="a">
+          <li>
+            Permission is granted to temporarily download one copy of the materials (information or software) on We All Code's web site for personal, non-commercial transitory viewing only. This is the grant of a license, not a transfer of title, and under this license you may not:
 
-          <ol type="i">
-            <li>modify or copy the materials;</li>
-            <li>use the materials for any commercial purpose, or for any public display (commercial or non-commercial);</li>
-            <li>attempt to decompile or reverse engineer any software contained on We All Code's web site;</li>
-            <li>remove any copyright or other proprietary notations from the materials; or</li>
-            <li>transfer the materials to another person or "mirror" the materials on any other server.</li>
-          </ol>
-        </li>
-        <li>
-          This license shall automatically terminate if you violate any of these restrictions and may be terminated by We All Code at any time. Upon terminating your viewing of these materials or upon the termination of this license, you must destroy any downloaded materials in your possession whether in electronic or printed format.
-        </li>
-      </ol>
+            <ol type="i">
+              <li>modify or copy the materials;</li>
+              <li>use the materials for any commercial purpose, or for any public display (commercial or non-commercial);</li>
+              <li>attempt to decompile or reverse engineer any software contained on We All Code's web site;</li>
+              <li>remove any copyright or other proprietary notations from the materials; or</li>
+              <li>transfer the materials to another person or "mirror" the materials on any other server.</li>
+            </ol>
+          </li>
+          <li>
+            This license shall automatically terminate if you violate any of these restrictions and may be terminated by We All Code at any time. Upon terminating your viewing of these materials or upon the termination of this license, you must destroy any downloaded materials in your possession whether in electronic or printed format.
+          </li>
+        </ol>
 
-      <h4 class="title">3. Disclaimer</h4>
+        <h4 class="title">3. Disclaimer</h4>
 
-      <ol type="a">
-        <li>The materials on We All Code's web site are provided "as is". We All Code makes no warranties, expressed or implied, and hereby disclaims and negates all other warranties, including without limitation, implied warranties or conditions of merchantability, fitness for a particular purpose, or non-infringement of intellectual property or other violation of rights. Further, We All Code does not warrant or make any representations concerning the accuracy, likely results, or reliability of the use of the materials on its Internet web site or otherwise relating to such materials or on any sites linked to this site.</li>
-      </ol>
+        <ol type="a">
+          <li>The materials on We All Code's web site are provided "as is". We All Code makes no warranties, expressed or implied, and hereby disclaims and negates all other warranties, including without limitation, implied warranties or conditions of merchantability, fitness for a particular purpose, or non-infringement of intellectual property or other violation of rights. Further, We All Code does not warrant or make any representations concerning the accuracy, likely results, or reliability of the use of the materials on its Internet web site or otherwise relating to such materials or on any sites linked to this site.</li>
+        </ol>
 
-      <h4 class="title">4. Limitations</h4>
+        <h4 class="title">4. Limitations</h4>
 
-      <p>In no event shall We All Code or its suppliers be liable for any damages (including, without limitation, damages for loss of data or profit, or due to business interruption,) arising out of the use or inability to use the materials on We All Code's Internet site, even if We All Code or a We All Code authorized representative has been notified orally or in writing of the possibility of such damage. Because some jurisdictions do not allow limitations on implied warranties, or limitations of liability for consequential or incidental damages, these limitations may not apply to you.</p>
+        <p>In no event shall We All Code or its suppliers be liable for any damages (including, without limitation, damages for loss of data or profit, or due to business interruption,) arising out of the use or inability to use the materials on We All Code's Internet site, even if We All Code or a We All Code authorized representative has been notified orally or in writing of the possibility of such damage. Because some jurisdictions do not allow limitations on implied warranties, or limitations of liability for consequential or incidental damages, these limitations may not apply to you.</p>
 
-      <h4 class="title">5. Revisions and Errata</h4>
+        <h4 class="title">5. Revisions and Errata</h4>
 
-      <p>The materials appearing on We All Code's web site could include technical, typographical, or photographic errors. We All Code does not warrant that any of the materials on its web site are accurate, complete, or current. We All Code may make changes to the materials contained on its web site at any time without notice. We All Code does not, however, make any commitment to update the materials.</p>
+        <p>The materials appearing on We All Code's web site could include technical, typographical, or photographic errors. We All Code does not warrant that any of the materials on its web site are accurate, complete, or current. We All Code may make changes to the materials contained on its web site at any time without notice. We All Code does not, however, make any commitment to update the materials.</p>
 
-      <h4 class="title">6. Links</h4>
+        <h4 class="title">6. Links</h4>
 
-      <p>We All Code has not reviewed all of the sites linked to its Internet web site and is not responsible for the contents of any such linked site. The inclusion of any link does not imply endorsement by We All Code of the site. Use of any such linked web site is at the user's own risk.</p>
+        <p>We All Code has not reviewed all of the sites linked to its Internet web site and is not responsible for the contents of any such linked site. The inclusion of any link does not imply endorsement by We All Code of the site. Use of any such linked web site is at the user's own risk.</p>
 
-      <h4 class="title">7. Site Terms of Use Modifications</h4>
+        <h4 class="title">7. Site Terms of Use Modifications</h4>
 
-      <p>We All Code may revise these terms of use for its web site at any time without notice. By using this web site you are agreeing to be bound by the then current version of these Terms and Conditions of Use.</p>
+        <p>We All Code may revise these terms of use for its web site at any time without notice. By using this web site you are agreeing to be bound by the then current version of these Terms and Conditions of Use.</p>
 
-      <h4 class="title">8. Governing Law</h4>
+        <h4 class="title">8. Governing Law</h4>
 
-      <p>Any claim relating to We All Code's web site shall be governed by the laws of the State of Illinois without regard to its conflict of law provisions.</p>
+        <p>Any claim relating to We All Code's web site shall be governed by the laws of the State of Illinois without regard to its conflict of law provisions.</p>
 
-      <p>General Terms and Conditions applicable to Use of a Web Site.</p>
+        <p>General Terms and Conditions applicable to Use of a Web Site.</p>
 
-      <h3 class="title">Privacy Policy</h3>
+        <h3 class="title">Privacy Policy</h3>
 
-      <p>Your privacy is very important to us. Accordingly, we have developed this Policy in order for you to understand how we collect, use, communicate and disclose and make use of personal information. The following outlines our privacy policy.</p>
+        <p>Your privacy is very important to us. Accordingly, we have developed this Policy in order for you to understand how we collect, use, communicate and disclose and make use of personal information. The following outlines our privacy policy.</p>
 
-      <ul>
-        <li>Before or at the time of collecting personal information, we will identify the purposes for which information is being collected.</li>
-        <li>We will collect and use of personal information solely with the objective of fulfilling those purposes specified by us and for other compatible purposes, unless we obtain the consent of the individual concerned or as required by law.</li>
-        <li>We will only retain personal information as long as necessary for the fulfillment of those purposes.</li>
-        <li>We will collect personal information by lawful and fair means and, where appropriate, with the knowledge or consent of the individual concerned.</li>
-        <li>Personal data should be relevant to the purposes for which it is to be used, and, to the extent necessary for those purposes, should be accurate, complete, and up-to-date.</li>
-        <li>We will protect personal information by reasonable security safeguards against loss or theft, as well as unauthorized access, disclosure, copying, use or modification.</li>
-        <li>We will make readily available to customers information about our policies and practices relating to the management of personal information.</li>
-      </ul>
+        <ul>
+          <li>Before or at the time of collecting personal information, we will identify the purposes for which information is being collected.</li>
+          <li>We will collect and use of personal information solely with the objective of fulfilling those purposes specified by us and for other compatible purposes, unless we obtain the consent of the individual concerned or as required by law.</li>
+          <li>We will only retain personal information as long as necessary for the fulfillment of those purposes.</li>
+          <li>We will collect personal information by lawful and fair means and, where appropriate, with the knowledge or consent of the individual concerned.</li>
+          <li>Personal data should be relevant to the purposes for which it is to be used, and, to the extent necessary for those purposes, should be accurate, complete, and up-to-date.</li>
+          <li>We will protect personal information by reasonable security safeguards against loss or theft, as well as unauthorized access, disclosure, copying, use or modification.</li>
+          <li>We will make readily available to customers information about our policies and practices relating to the management of personal information.</li>
+        </ul>
 
-      <p>We are committed to conducting our business in accordance with these principles in order to ensure that the confidentiality of personal information is protected and maintained.</p>
-    </div>
-  </section>
+        <p>We are committed to conducting our business in accordance with these principles in order to ensure that the confidentiality of personal information is protected and maintained.</p>
+      </div>
+    </section>
+  </main>
 {% endblock content %}

--- a/weallcode/templates/weallcode/programs.html
+++ b/weallcode/templates/weallcode/programs.html
@@ -16,9 +16,9 @@
 {% endblock subheader %}
 
 {% block content %}
-  <main id="main">
-    {% include "weallcode/snippets/hero_image.html" with src="weallcode/images/photos/hero-programs.jpg" alt="programs" %}
+  {% include "weallcode/snippets/hero_image.html" with src="weallcode/images/photos/hero-programs.jpg" alt="programs" %}
 
+  <main id="main">
     <section id="classes" class="padding-vertical-3">
       <div class="grid-container">
         <div class="grid-x margin-bottom-3">

--- a/weallcode/templates/weallcode/programs.html
+++ b/weallcode/templates/weallcode/programs.html
@@ -16,176 +16,178 @@
 {% endblock subheader %}
 
 {% block content %}
-  {% include "weallcode/snippets/hero_image.html" with src="weallcode/images/photos/hero-programs.jpg" alt="programs" %}
+  <main id="main">
+    {% include "weallcode/snippets/hero_image.html" with src="weallcode/images/photos/hero-programs.jpg" alt="programs" %}
 
-  <main id="classes" class="padding-vertical-3">
-    <div class="grid-container">
-      <div class="grid-x margin-bottom-3">
-        <div class="cell large-8 padding-right-2">
-          <h1 class="title text-tertiary margin-bottom-2">Programs</h1>
-          <p>We All Code Programs are built on our single-day, interactive <strong>Classes</strong>. During these 3-to-5 hour weekend sessions, kids learn about one specific coding topic, like HTML 1.0.</p>
-          <p>Classes progress in skill level and can be combined to create full <strong>Courses</strong> in HTML, CSS, Python, and Javascript. </p>
-        </div>
-        <div class="cell large-4 position-relative">
-          <div class="aside-title">
-            <div>
-              <span class="text-tertiary display-inline-block">Step by step </span>
-              <span class="text-tertiary display-inline-block">instruction.</span>
+    <section id="classes" class="padding-vertical-3">
+      <div class="grid-container">
+        <div class="grid-x margin-bottom-3">
+          <div class="cell large-8 padding-right-2">
+            <h1 class="title text-tertiary margin-bottom-2">Programs</h1>
+            <p>We All Code Programs are built on our single-day, interactive <strong>Classes</strong>. During these 3-to-5 hour weekend sessions, kids learn about one specific coding topic, like HTML 1.0.</p>
+            <p>Classes progress in skill level and can be combined to create full <strong>Courses</strong> in HTML, CSS, Python, and Javascript. </p>
+          </div>
+          <div class="cell large-4 position-relative">
+            <div class="aside-title">
+              <div>
+                <span class="text-tertiary display-inline-block">Step by step </span>
+                <span class="text-tertiary display-inline-block">instruction.</span>
+              </div>
+              <div>
+                <span class="text-secondary display-inline-block">A whole lot </span>
+                <span class="text-white display-inline-block">of fun!</span>
+              </div>
+              <div class="line width-25 bg-primary margin-top-1"></div>
             </div>
-            <div>
-              <span class="text-secondary display-inline-block">A whole lot </span>
-              <span class="text-white display-inline-block">of fun!</span>
-            </div>
-            <div class="line width-25 bg-primary margin-top-1"></div>
           </div>
         </div>
+
+        <h2 class="title text-tertiary margin-bottom-2">Upcoming Classes</h2>
+
+        {% if weekend_classes %}
+          {% for session in weekend_classes %}
+            {% include "weallcode/snippets/class.html" with session=session %}
+          {% endfor %}
+        {% else %}
+          <div class="grid-x bg-dark-blue text-white padding-2"><p class="h4">We All Code strives to provide every child the chance to excel in one of the emerging fields of STEM. Over the next few weeks, the team is hard at work planning classes for 2021. We are excited to continue offering classes that are diverse, experiential, and spark curiosity in every student. Please check back for program details at the start of the new year!</p></div>
+        {% endif %}
       </div>
+    </section>
 
-      <h2 class="title text-tertiary margin-bottom-2">Upcoming Classes</h2>
+    <section id="summer-camps" class="padding-vertical-3 margin-bottom-2">
+      <div class="grid-container">
+        <h2 class="title text-tertiary margin-bottom-2">Summer Camps</h2>
+        <p>During these week-long summer experiences, kids get the chance to practice in-depth skills like project management, quality assurance, and teamwork while tackling a coding project.</p>
 
-      {% if weekend_classes %}
-        {% for session in weekend_classes %}
-          {% include "weallcode/snippets/class.html" with session=session %}
-        {% endfor %}
-      {% else %}
-        <div class="grid-x bg-dark-blue text-white padding-2"><p class="h4">We All Code strives to provide every child the chance to excel in one of the emerging fields of STEM. Over the next few weeks, the team is hard at work planning classes for 2021. We are excited to continue offering classes that are diverse, experiential, and spark curiosity in every student. Please check back for program details at the start of the new year!</p></div>
-      {% endif %}
-    </div>
+        {% if summer_camp_classes %}
+          {% for session in summer_camp_classes %}
+            {% include "weallcode/snippets/class.html" with session=session %}
+          {% endfor %}
+        {% else %}
+          <p>There are no upcoming summer camps at this time. Please <a href="{% url 'weallcode-join-us' %}#contact">contact us</a> for more information.</p>
+        {% endif %}
+
+        {% include "weallcode/snippets/posters.html" with svg_href_1="#svg-management" title_1="Project Management" content_1="Kids learn to manage the moving parts of a project." svg_href_2="#svg-backend" title_2="Quality Assurance" content_2="We teach kids the right way to complete a project." svg_href_3="#svg-high5" title_3="Socialization Skills" content_3="Kids spend the week completing a project in teams and making new friends." %}
+      </div>
+    </section>
+
+    <section id="pathways" class="padding-vertical-3">
+      <div class="grid-container">
+        <h2 class="title text-tertiary margin-bottom-2">Pathways</h2>
+        <p>Pathways help kids envision a future in STEM by building real-world skills that go beyond coding. They’ll learn Front-End Development, Back-End Development, or Design & Communication in a safe, supportive, and experiential environment.</p>
+
+        {% include "weallcode/snippets/posters.html" with svg_href_1="#svg-frontend" title_1="Front-end Development" content_1="Learn how HTML, CSS, and JavaScript work together to build beautiful sites." svg_href_2="#svg-backend" title_2="Back-end Development" content_2="Learn how coding languages like Java and Python can power everything from robots to the internet." svg_href_3="#svg-design" title_3="Design &amp; Communication" content_3="Learn how real coders design websites, manage projects and communicate." %}
+      </div>
+    </section>
+
+    <section id="courses" class="padding-vertical-3">
+      <div class="grid-container">
+        <h2 class="title text-tertiary margin-bottom-2">Courses</h2>
+
+        <div class="grid-x bg-dark-blue text-white margin-top-2 padding-vertical-2 padding-horizontal-2">
+          <div class="cell medium-6 large-7 padding-right-2">
+            <h2>HTML 101</h2>
+            <h4>Choose Your Own Adventure</h4>
+          </div>
+          <div class="cell small-6 medium-3 large-2">
+            <h6 class="text-uppercase margin-top-1">Prerequisities</h6>
+            <ul class="list-plus">
+              <li>None</li>
+            </ul>
+          </div>
+          <div class="cell small-6 medium-3">
+            <h6 class="text-uppercase margin-top-1">Pathways</h6>
+            <ul class="list-plus">
+              <li>Front-end Development</li>
+            </ul>
+          </div>
+          <div class="cell">
+            <div class="line bg-primary width-50 margin-vertical-2"></div>
+            <p><strong>Ages</strong>: Open to everyone</p>
+            <p>Ever wonder how the web can deliver everything from Minecraft maps to YouTube Videos?</p>
+            <p>In this course, students will develop an understanding of how HTML is used to define the structure of web pages, then use their knowledge to hack together their own &quot;Choose Your Own Adventure&quot; game.</p>
+            <p>By the end of the course, students will understand how the language HTML, CSS, and Javascript come together.</p>
+          </div>
+        </div>
+
+        <div class="grid-x bg-dark-blue text-white margin-top-2 padding-vertical-2 padding-horizontal-2">
+          <div class="cell medium-6 large-7 padding-right-2">
+            <h2>CSS 101</h2>
+            <h4>Designing Your Adventure</h4>
+          </div>
+          <div class="cell small-6 medium-3 large-2">
+            <h6 class="text-uppercase margin-top-1">Prerequisities</h6>
+            <ul class="list-plus">
+              <li>HTML 101</li>
+            </ul>
+          </div>
+          <div class="cell small-6 medium-3">
+            <h6 class="text-uppercase margin-top-1">Pathways</h6>
+            <ul class="list-plus">
+              <li>Front-end Development</li>
+              <li>Design</li>
+            </ul>
+          </div>
+          <div class="cell">
+            <div class="line bg-secondary width-50 margin-vertical-2"></div>
+            <p><strong>Ages</strong>: Open to everyone</p>
+            <p>Mastered HTML and ready to add some personality to your website?</p>
+            <p>In this course, students will develop an understanding of how to control the design and layout of web pages, then use their knowledge to style their own profile page. By the end of the course, students will understand how CSS enhances the look of the web.</p>
+          </div>
+        </div>
+
+        <div class="grid-x bg-dark-blue text-white margin-top-2 padding-vertical-2 padding-horizontal-2">
+          <div class="cell medium-6 large-7 padding-right-2">
+            <h2>JS 101</h2>
+            <h4>Drawing with Javascript</h4>
+          </div>
+          <div class="cell small-6 medium-3 large-2">
+            <h6 class="text-uppercase margin-top-1">Prerequisities</h6>
+            <ul class="list-plus">
+              <li>None</li>
+            </ul>
+          </div>
+          <div class="cell small-6 medium-3">
+            <h6 class="text-uppercase margin-top-1">Pathways</h6>
+            <ul class="list-plus">
+              <li>Front-end Development</li>
+            </ul>
+          </div>
+          <div class="cell">
+            <div class="line bg-tertiary width-50 margin-vertical-2"></div>
+            <p><strong>Ages</strong> 10+ or <strong>Grade</strong> 5+</p>
+            <p>Ever wanted to start building your own game but didn't know where to start? Ever thought it would be cool to draw or animate using the computer?</p>
+            <p>In this course, students will learn how to break down tasks and objects to understand how they are built. By the end of the course, students will understand how to use the Javascript programming language in Canvas.</p>
+          </div>
+        </div>
+
+        <div class="grid-x bg-dark-blue text-white margin-top-2 padding-vertical-2 padding-horizontal-2">
+          <div class="cell medium-6 large-7 padding-right-2">
+            <h2>PY 101</h2>
+            <h4>Robotics with Python</h4>
+          </div>
+          <div class="cell small-6 medium-3 large-2">
+            <h6 class="text-uppercase margin-top-1">Prerequisities</h6>
+            <ul class="list-plus">
+              <li>None</li>
+            </ul>
+          </div>
+          <div class="cell small-6 medium-3">
+            <h6 class="text-uppercase margin-top-1">Pathways</h6>
+            <ul class="list-plus">
+              <li>Back-end Development</li>
+            </ul>
+          </div>
+          <div class="cell">
+            <div class="line bg-gray-for-blue width-50 margin-vertical-2"></div>
+            <p><strong>Ages</strong> 10+ or <strong>Grade</strong> 5+</p>
+            <p>Want to learn what makes robotics work?</p>
+            <p>In this course, students and their guardians will gain a basic understanding of the Python programming language and how to use it to "drive" their robots.</p>
+          </div>
+        </div>
+
+      </div>
+    </section>
   </main>
-
-  <section id="summer-camps" class="padding-vertical-3 margin-bottom-2">
-    <div class="grid-container">
-      <h2 class="title text-tertiary margin-bottom-2">Summer Camps</h2>
-      <p>During these week-long summer experiences, kids get the chance to practice in-depth skills like project management, quality assurance, and teamwork while tackling a coding project.</p>
-
-      {% if summer_camp_classes %}
-        {% for session in summer_camp_classes %}
-          {% include "weallcode/snippets/class.html" with session=session %}
-        {% endfor %}
-      {% else %}
-        <p>There are no upcoming summer camps at this time. Please <a href="{% url 'weallcode-join-us' %}#contact">contact us</a> for more information.</p>
-      {% endif %}
-
-      {% include "weallcode/snippets/posters.html" with svg_href_1="#svg-management" title_1="Project Management" content_1="Kids learn to manage the moving parts of a project." svg_href_2="#svg-backend" title_2="Quality Assurance" content_2="We teach kids the right way to complete a project." svg_href_3="#svg-high5" title_3="Socialization Skills" content_3="Kids spend the week completing a project in teams and making new friends." %}
-    </div>
-  </section>
-
-  <section id="pathways" class="padding-vertical-3">
-    <div class="grid-container">
-      <h2 class="title text-tertiary margin-bottom-2">Pathways</h2>
-      <p>Pathways help kids envision a future in STEM by building real-world skills that go beyond coding. They’ll learn Front-End Development, Back-End Development, or Design & Communication in a safe, supportive, and experiential environment.</p>
-
-      {% include "weallcode/snippets/posters.html" with svg_href_1="#svg-frontend" title_1="Front-end Development" content_1="Learn how HTML, CSS, and JavaScript work together to build beautiful sites." svg_href_2="#svg-backend" title_2="Back-end Development" content_2="Learn how coding languages like Java and Python can power everything from robots to the internet." svg_href_3="#svg-design" title_3="Design &amp; Communication" content_3="Learn how real coders design websites, manage projects and communicate." %}
-    </div>
-  </section>
-
-  <section id="courses" class="padding-vertical-3">
-    <div class="grid-container">
-      <h2 class="title text-tertiary margin-bottom-2">Courses</h2>
-
-      <div class="grid-x bg-dark-blue text-white margin-top-2 padding-vertical-2 padding-horizontal-2">
-        <div class="cell medium-6 large-7 padding-right-2">
-          <h2>HTML 101</h2>
-          <h4>Choose Your Own Adventure</h4>
-        </div>
-        <div class="cell small-6 medium-3 large-2">
-          <h6 class="text-uppercase margin-top-1">Prerequisities</h6>
-          <ul class="list-plus">
-            <li>None</li>
-          </ul>
-        </div>
-        <div class="cell small-6 medium-3">
-          <h6 class="text-uppercase margin-top-1">Pathways</h6>
-          <ul class="list-plus">
-            <li>Front-end Development</li>
-          </ul>
-        </div>
-        <div class="cell">
-          <div class="line bg-primary width-50 margin-vertical-2"></div>
-          <p><strong>Ages</strong>: Open to everyone</p>
-          <p>Ever wonder how the web can deliver everything from Minecraft maps to YouTube Videos?</p>
-          <p>In this course, students will develop an understanding of how HTML is used to define the structure of web pages, then use their knowledge to hack together their own &quot;Choose Your Own Adventure&quot; game.</p>
-          <p>By the end of the course, students will understand how the language HTML, CSS, and Javascript come together.</p>
-        </div>
-      </div>
-
-      <div class="grid-x bg-dark-blue text-white margin-top-2 padding-vertical-2 padding-horizontal-2">
-        <div class="cell medium-6 large-7 padding-right-2">
-          <h2>CSS 101</h2>
-          <h4>Designing Your Adventure</h4>
-        </div>
-        <div class="cell small-6 medium-3 large-2">
-          <h6 class="text-uppercase margin-top-1">Prerequisities</h6>
-          <ul class="list-plus">
-            <li>HTML 101</li>
-          </ul>
-        </div>
-        <div class="cell small-6 medium-3">
-          <h6 class="text-uppercase margin-top-1">Pathways</h6>
-          <ul class="list-plus">
-            <li>Front-end Development</li>
-            <li>Design</li>
-          </ul>
-        </div>
-        <div class="cell">
-          <div class="line bg-secondary width-50 margin-vertical-2"></div>
-          <p><strong>Ages</strong>: Open to everyone</p>
-          <p>Mastered HTML and ready to add some personality to your website?</p>
-          <p>In this course, students will develop an understanding of how to control the design and layout of web pages, then use their knowledge to style their own profile page. By the end of the course, students will understand how CSS enhances the look of the web.</p>
-        </div>
-      </div>
-
-      <div class="grid-x bg-dark-blue text-white margin-top-2 padding-vertical-2 padding-horizontal-2">
-        <div class="cell medium-6 large-7 padding-right-2">
-          <h2>JS 101</h2>
-          <h4>Drawing with Javascript</h4>
-        </div>
-        <div class="cell small-6 medium-3 large-2">
-          <h6 class="text-uppercase margin-top-1">Prerequisities</h6>
-          <ul class="list-plus">
-            <li>None</li>
-          </ul>
-        </div>
-        <div class="cell small-6 medium-3">
-          <h6 class="text-uppercase margin-top-1">Pathways</h6>
-          <ul class="list-plus">
-            <li>Front-end Development</li>
-          </ul>
-        </div>
-        <div class="cell">
-          <div class="line bg-tertiary width-50 margin-vertical-2"></div>
-          <p><strong>Ages</strong> 10+ or <strong>Grade</strong> 5+</p>
-          <p>Ever wanted to start building your own game but didn't know where to start? Ever thought it would be cool to draw or animate using the computer?</p>
-          <p>In this course, students will learn how to break down tasks and objects to understand how they are built. By the end of the course, students will understand how to use the Javascript programming language in Canvas.</p>
-        </div>
-      </div>
-
-      <div class="grid-x bg-dark-blue text-white margin-top-2 padding-vertical-2 padding-horizontal-2">
-        <div class="cell medium-6 large-7 padding-right-2">
-          <h2>PY 101</h2>
-          <h4>Robotics with Python</h4>
-        </div>
-        <div class="cell small-6 medium-3 large-2">
-          <h6 class="text-uppercase margin-top-1">Prerequisities</h6>
-          <ul class="list-plus">
-            <li>None</li>
-          </ul>
-        </div>
-        <div class="cell small-6 medium-3">
-          <h6 class="text-uppercase margin-top-1">Pathways</h6>
-          <ul class="list-plus">
-            <li>Back-end Development</li>
-          </ul>
-        </div>
-        <div class="cell">
-          <div class="line bg-gray-for-blue width-50 margin-vertical-2"></div>
-          <p><strong>Ages</strong> 10+ or <strong>Grade</strong> 5+</p>
-          <p>Want to learn what makes robotics work?</p>
-          <p>In this course, students and their guardians will gain a basic understanding of the Python programming language and how to use it to "drive" their robots.</p>
-        </div>
-      </div>
-
-    </div>
-  </section>
 
 {% endblock content %}

--- a/weallcode/templates/weallcode/programs_summer_camps.html
+++ b/weallcode/templates/weallcode/programs_summer_camps.html
@@ -16,9 +16,9 @@
 {% endblock subheader %}
 
 {% block content %}
-  <main id="main">
-    {% include "weallcode/snippets/hero_image.html" with src="weallcode/images/photos/hero-programs.jpg" alt="programs" %}
+  {% include "weallcode/snippets/hero_image.html" with src="weallcode/images/photos/hero-programs.jpg" alt="programs" %}
 
+  <main id="main">
     <section id="summer-camps" class="padding-vertical-3 margin-bottom-2">
       <div class="grid-container">
         <h2 class="title text-tertiary margin-bottom-2">Summer Camps</h2>

--- a/weallcode/templates/weallcode/programs_summer_camps.html
+++ b/weallcode/templates/weallcode/programs_summer_camps.html
@@ -16,22 +16,24 @@
 {% endblock subheader %}
 
 {% block content %}
-  {% include "weallcode/snippets/hero_image.html" with src="weallcode/images/photos/hero-programs.jpg" alt="programs" %}
+  <main id="main">
+    {% include "weallcode/snippets/hero_image.html" with src="weallcode/images/photos/hero-programs.jpg" alt="programs" %}
 
-  <section id="summer-camps" class="padding-vertical-3 margin-bottom-2">
-    <div class="grid-container">
-      <h2 class="title text-tertiary margin-bottom-2">Summer Camps</h2>
-      <p>During these week-long summer experiences, kids get the chance to practice in-depth skills like project management, quality assurance, and teamwork while tackling a coding project.</p>
+    <section id="summer-camps" class="padding-vertical-3 margin-bottom-2">
+      <div class="grid-container">
+        <h2 class="title text-tertiary margin-bottom-2">Summer Camps</h2>
+        <p>During these week-long summer experiences, kids get the chance to practice in-depth skills like project management, quality assurance, and teamwork while tackling a coding project.</p>
 
-      {% if summer_camp_classes %}
-        {% for session in summer_camp_classes %}
-          {% include "weallcode/snippets/class.html" with session=session %}
-        {% endfor %}
-      {% else %}
-        <p>There are no upcoming summer camps at this time. Please <a href="{% url 'weallcode-join-us' %}#contact">contact us</a> for more information.</p>
-      {% endif %}
+        {% if summer_camp_classes %}
+          {% for session in summer_camp_classes %}
+            {% include "weallcode/snippets/class.html" with session=session %}
+          {% endfor %}
+        {% else %}
+          <p>There are no upcoming summer camps at this time. Please <a href="{% url 'weallcode-join-us' %}#contact">contact us</a> for more information.</p>
+        {% endif %}
 
-      {% include "weallcode/snippets/posters.html" with svg_href_1="#svg-management" title_1="Project Management" content_1="Kids learn to manage the moving parts of a project." svg_href_2="#svg-backend" title_2="Quality Assurance" content_2="We teach kids the right way to complete a project." svg_href_3="#svg-high5" title_3="Socialization Skills" content_3="Kids spend the week completing a project in teams and making new friends." %}
-    </div>
-  </section>
+        {% include "weallcode/snippets/posters.html" with svg_href_1="#svg-management" title_1="Project Management" content_1="Kids learn to manage the moving parts of a project." svg_href_2="#svg-backend" title_2="Quality Assurance" content_2="We teach kids the right way to complete a project." svg_href_3="#svg-high5" title_3="Socialization Skills" content_3="Kids spend the week completing a project in teams and making new friends." %}
+      </div>
+    </section>
+  </main>
 {% endblock content %}

--- a/weallcode/templates/weallcode/snippets/class.html
+++ b/weallcode/templates/weallcode/snippets/class.html
@@ -1,4 +1,4 @@
-<div class="grid-x text-white margin-top-2">
+<div class="class-info-box grid-x text-white margin-top-2">
   <div class="cell medium-8 bg-dark-blue padding-2">
     <a class="text-white" href="{{ session.get_absolute_url }}">
       <h2>{{ session.course.code }}</h2>

--- a/weallcode/templates/weallcode/team.html
+++ b/weallcode/templates/weallcode/team.html
@@ -20,178 +20,180 @@
 {% endblock subheader %}
 
 {% block content %}
-{% include "weallcode/snippets/hero_image.html" with src="weallcode/images/photos/hero-team.jpg" alt="our team" %}
+<main id="main">
+  {% include "weallcode/snippets/hero_image.html" with src="weallcode/images/photos/hero-team.jpg" alt="our team" %}
 
-<section class="padding-vertical-3">
-  <div class="grid-container">
-    <div class="grid-x">
-      <div class="cell large-7 text-center medium-text-left">
-        <h1 class="title text-tertiary margin-bottom-2">The Team</h1>
-        <p>Our dedicated team works hard to keep We All Code classes safe, supportive, and largely free. Our leaders, instructors, mentors, and volunteers work to help every child explore their kid creativity through coding.</p>
-      </div>
-      <div class="cell large-offset-1 large-4 position-relative">
-        <div class="aside-title">
-          <div>
-            <span class="text-tertiary display-inline-block">Team work </span>
-            <span class="text-tertiary display-inline-block">makes </span>
-            <span class="text-secondary display-inline-block">the dream </span>
-            <span class="text-white display-inline-block">work</span>
+  <section class="padding-vertical-3">
+    <div class="grid-container">
+      <div class="grid-x">
+        <div class="cell large-7 text-center medium-text-left">
+          <h1 class="title text-tertiary margin-bottom-2">The Team</h1>
+          <p>Our dedicated team works hard to keep We All Code classes safe, supportive, and largely free. Our leaders, instructors, mentors, and volunteers work to help every child explore their kid creativity through coding.</p>
+        </div>
+        <div class="cell large-offset-1 large-4 position-relative">
+          <div class="aside-title">
+            <div>
+              <span class="text-tertiary display-inline-block">Team work </span>
+              <span class="text-tertiary display-inline-block">makes </span>
+              <span class="text-secondary display-inline-block">the dream </span>
+              <span class="text-white display-inline-block">work</span>
+            </div>
+            <div class="line width-25 bg-primary margin-top-1"></div>
           </div>
-          <div class="line width-25 bg-primary margin-top-1"></div>
         </div>
       </div>
     </div>
-  </div>
-</section>
+  </section>
 
-<!-- Leadership -->
-<section id="leadership" class="bg-dark-blue text-center padding-vertical-3">
-  <div class="grid-container">
-    <div class="text-white">
-      <h2 class="title">Leadership</h2>
-      <p class="medium-padding-horizontal-3">Our full-time leadership staff works tirelessly toward one purpose: bringing STEM learning opportunities to every kid in Chicago and giving them the tools they need to excel.</p>
-    </div>
-
-    <div class="grid-x grid-margin-x grid-margin-y margin-top-2 align-center">
-      {% for person in staff %}
-        <div class="cell small-6">
-          {% include "weallcode/snippets/team_member.html" with is_on_dark=True color="secondary" name=person.name title=person.role image=person.image %}
-        </div>
-      {% endfor %}
-    </div>
-  </div>
-</section>
-
-<!-- Board -->
-<section id="board" class="text-center padding-vertical-3 bg-light-gray">
-  <div class="grid-container">
-    <h2 class="title text-tertiary">Board</h2>
-    <p class="medium-padding-horizontal-3">Our dedicated board includes leaders from diverse backgrounds and fields across Chicago.</p>
-
-    <div class="grid-x grid-margin-x grid-margin-y margin-top-2">
-      {% for member in board %}
-        <div class="cell small-6 medium-4">
-          {% include "weallcode/snippets/team_member.html" with is_small=True name=member.name image=member.image title=member.role description=member.description link=member.linkedin color="tertiary" %}
-        </div>
-      {% endfor %}
-    </div>
-  </div>
-</section>
-
-<!-- Associate Board -->
-<section id="associate-board" class="text-center padding-vertical-3">
-  <div class="grid-container">
-    <h2 class="title text-primary">Associate Board</h2>
-    <p class="medium-padding-horizontal-3">Our Associate Board of young professionals fuels our big ideas and is dedicated to We All Code's growth.</p>
-
-    <div class="grid-x grid-margin-x grid-margin-y margin-top-2">
-      {% for member in associate_board %}
-        <div class="cell small-6 medium-3">
-          {% include "weallcode/snippets/team_member.html" with is_small=True name=member.name image=member.image title=member.role description=member.description link=member.linkedin color="primary" %}
-        </div>
-      {% endfor %}
-    </div>
-  </div>
-</section>
-
-<!-- Instructors -->
-<section id="instructors" class="bg-dark-blue text-center padding-vertical-3">
-  <div class="grid-container">
-    <div class="text-white">
-      <h2 class="title">Instructors</h2>
-      <p class="medium-padding-horizontal-3">These highly-trained volunteers come from tech backgrounds and are skilled in creating a supportive, experiential learning environment to help every kid code.</p>
-    </div>
-
-    <div class="grid-x grid-margin-x grid-margin-y margin-top-2">
-      {% for instructor in instructors %}
-        <div class="cell small-6 medium-4">
-          {% include "weallcode/snippets/team_member.html" with is_on_dark=True name=instructor.user.name image=instructor.avatar %}
-        </div>
-      {% endfor %}
-
-    </div>
-  </div>
-</section>
-
-<!-- Mentors -->
-<section id="mentors" class="padding-vertical-3 bg-light-gray">
-  <div class="grid-container">
-    <div class="grid-x grid-padding-x">
-      <div class="cell medium-5">
-        <h2 class="title text-tertiary">Mentorship makes all the difference</h2>
-        <p>Our volunteer mentors help students feel supported as they learn to code. We're proud of our exceptional 2-to-1 mentor-to-student ratio, ensuring your kids will always have a friendly face to turn to with questions.</p>
+  <!-- Leadership -->
+  <section id="leadership" class="bg-dark-blue text-center padding-vertical-3">
+    <div class="grid-container">
+      <div class="text-white">
+        <h2 class="title">Leadership</h2>
+        <p class="medium-padding-horizontal-3">Our full-time leadership staff works tirelessly toward one purpose: bringing STEM learning opportunities to every kid in Chicago and giving them the tools they need to excel.</p>
       </div>
-      <div class="cell medium-offset-1 medium-6">
-        <div class="binary-drop-right">
-          <img class="width-100" src="{% static 'weallcode/images/photos/mentoring.jpg' %}" alt="mentors">
-        </div>
+
+      <div class="grid-x grid-margin-x grid-margin-y margin-top-2 align-center">
+        {% for person in staff %}
+          <div class="cell small-6">
+            {% include "weallcode/snippets/team_member.html" with is_on_dark=True color="secondary" name=person.name title=person.role image=person.image %}
+          </div>
+        {% endfor %}
       </div>
     </div>
+  </section>
 
-    <div class="grid-x grid-margin-x grid-margin-y margin-top-3">
-      {% for mentor in top_mentors %}
-        <div class="cell small-6 medium-3">
-          {% include "weallcode/snippets/team_member.html" with is_small=True name=mentor.full_name label=mentor.session_count image=mentor.avatar sublabel="classes" %}
-        </div>
-      {% endfor %}
+  <!-- Board -->
+  <section id="board" class="text-center padding-vertical-3 bg-light-gray">
+    <div class="grid-container">
+      <h2 class="title text-tertiary">Board</h2>
+      <p class="medium-padding-horizontal-3">Our dedicated board includes leaders from diverse backgrounds and fields across Chicago.</p>
+
+      <div class="grid-x grid-margin-x grid-margin-y margin-top-2">
+        {% for member in board %}
+          <div class="cell small-6 medium-4">
+            {% include "weallcode/snippets/team_member.html" with is_small=True name=member.name image=member.image title=member.role description=member.description link=member.linkedin color="tertiary" %}
+          </div>
+        {% endfor %}
+      </div>
     </div>
+  </section>
 
-    {% if other_mentors %}
-      <div class="mentor-toggle hide grid-x grid-margin-x grid-margin-y margin-top-1">
-        {% for mentor in other_mentors %}
+  <!-- Associate Board -->
+  <section id="associate-board" class="text-center padding-vertical-3">
+    <div class="grid-container">
+      <h2 class="title text-primary">Associate Board</h2>
+      <p class="medium-padding-horizontal-3">Our Associate Board of young professionals fuels our big ideas and is dedicated to We All Code's growth.</p>
+
+      <div class="grid-x grid-margin-x grid-margin-y margin-top-2">
+        {% for member in associate_board %}
+          <div class="cell small-6 medium-3">
+            {% include "weallcode/snippets/team_member.html" with is_small=True name=member.name image=member.image title=member.role description=member.description link=member.linkedin color="primary" %}
+          </div>
+        {% endfor %}
+      </div>
+    </div>
+  </section>
+
+  <!-- Instructors -->
+  <section id="instructors" class="bg-dark-blue text-center padding-vertical-3">
+    <div class="grid-container">
+      <div class="text-white">
+        <h2 class="title">Instructors</h2>
+        <p class="medium-padding-horizontal-3">These highly-trained volunteers come from tech backgrounds and are skilled in creating a supportive, experiential learning environment to help every kid code.</p>
+      </div>
+
+      <div class="grid-x grid-margin-x grid-margin-y margin-top-2">
+        {% for instructor in instructors %}
+          <div class="cell small-6 medium-4">
+            {% include "weallcode/snippets/team_member.html" with is_on_dark=True name=instructor.user.name image=instructor.avatar %}
+          </div>
+        {% endfor %}
+
+      </div>
+    </div>
+  </section>
+
+  <!-- Mentors -->
+  <section id="mentors" class="padding-vertical-3 bg-light-gray">
+    <div class="grid-container">
+      <div class="grid-x grid-padding-x">
+        <div class="cell medium-5">
+          <h2 class="title text-tertiary">Mentorship makes all the difference</h2>
+          <p>Our volunteer mentors help students feel supported as they learn to code. We're proud of our exceptional 2-to-1 mentor-to-student ratio, ensuring your kids will always have a friendly face to turn to with questions.</p>
+        </div>
+        <div class="cell medium-offset-1 medium-6">
+          <div class="binary-drop-right">
+            <img class="width-100" src="{% static 'weallcode/images/photos/mentoring.jpg' %}" alt="mentors">
+          </div>
+        </div>
+      </div>
+
+      <div class="grid-x grid-margin-x grid-margin-y margin-top-3">
+        {% for mentor in top_mentors %}
           <div class="cell small-6 medium-3">
             {% include "weallcode/snippets/team_member.html" with is_small=True name=mentor.full_name label=mentor.session_count image=mentor.avatar sublabel="classes" %}
           </div>
         {% endfor %}
       </div>
 
-      <div class="mentor-toggle text-center margin-vertical-2">
-        <button class="button secondary" data-toggler=".mentor-toggle" data-toggle-class="hide">See More Mentors</button>
-      </div>
-    {% endif %}
-  </div>
-</section>
+      {% if other_mentors %}
+        <div class="mentor-toggle hide grid-x grid-margin-x grid-margin-y margin-top-1">
+          {% for mentor in other_mentors %}
+            <div class="cell small-6 medium-3">
+              {% include "weallcode/snippets/team_member.html" with is_small=True name=mentor.full_name label=mentor.session_count image=mentor.avatar sublabel="classes" %}
+            </div>
+          {% endfor %}
+        </div>
 
-<!-- Volunteers -->
-<section id="volunteers" class="padding-vertical-3">
-  <div class="grid-container">
-    <div class="grid-x grid-padding-x">
-      <div class="cell show-for-large large-6">
-        <div class="binary-drop-left">
-          <img class="width-100" src="{% static 'weallcode/images/photos/volunteering.jpg' %}" alt="volunteers">
+        <div class="mentor-toggle text-center margin-vertical-2">
+          <button class="button secondary" data-toggler=".mentor-toggle" data-toggle-class="hide">See More Mentors</button>
+        </div>
+      {% endif %}
+    </div>
+  </section>
+
+  <!-- Volunteers -->
+  <section id="volunteers" class="padding-vertical-3">
+    <div class="grid-container">
+      <div class="grid-x grid-padding-x">
+        <div class="cell show-for-large large-6">
+          <div class="binary-drop-left">
+            <img class="width-100" src="{% static 'weallcode/images/photos/volunteering.jpg' %}" alt="volunteers">
+          </div>
+        </div>
+        <div class="cell large-offset-1 large-5">
+          <h2 class="title text-primary">Volunteering for a better tomorrow</h2>
+          <p>Volunteers make our mission a reality! We rely on them to keep sessions running smoothly. Interested in volunteering?</p>
+          <a class="button large" href="{% url 'account_signup' %}">Become a Volunteer</a>
         </div>
       </div>
-      <div class="cell large-offset-1 large-5">
-        <h2 class="title text-primary">Volunteering for a better tomorrow</h2>
-        <p>Volunteers make our mission a reality! We rely on them to keep sessions running smoothly. Interested in volunteering?</p>
-        <a class="button large" href="{% url 'account_signup' %}">Become a Volunteer</a>
-      </div>
-    </div>
 
-    <div class="grid-x grid-margin-x grid-margin-y margin-top-3">
-      {% for volunteer in top_volunteers %}
-        <div class="cell small-6 medium-3">
-          {% include "weallcode/snippets/team_member.html" with is_small=True name=volunteer.full_name label=volunteer.session_count image=volunteer.avatar sublabel="classes" %}
-        </div>
-      {% endfor %}
-    </div>
-
-    <div class="volunteer-toggle hide grid-x grid-margin-x grid-margin-y margin-top-1">
-      {% for volunteer in other_volunteers %}
-        {% if volunteer.session_count %}
+      <div class="grid-x grid-margin-x grid-margin-y margin-top-3">
+        {% for volunteer in top_volunteers %}
           <div class="cell small-6 medium-3">
             {% include "weallcode/snippets/team_member.html" with is_small=True name=volunteer.full_name label=volunteer.session_count image=volunteer.avatar sublabel="classes" %}
           </div>
-        {% endif %}
-      {% endfor %}
-    </div>
-
-    {% if other_volunteers %}
-      <div class="volunteer-toggle text-center margin-vertical-2">
-        <button class="button secondary" data-toggler=".volunteer-toggle" data-toggle-class="hide">See More Volunteers</button>
+        {% endfor %}
       </div>
-    {% endif %}
 
-  </div>
-</section>
+      <div class="volunteer-toggle hide grid-x grid-margin-x grid-margin-y margin-top-1">
+        {% for volunteer in other_volunteers %}
+          {% if volunteer.session_count %}
+            <div class="cell small-6 medium-3">
+              {% include "weallcode/snippets/team_member.html" with is_small=True name=volunteer.full_name label=volunteer.session_count image=volunteer.avatar sublabel="classes" %}
+            </div>
+          {% endif %}
+        {% endfor %}
+      </div>
+
+      {% if other_volunteers %}
+        <div class="volunteer-toggle text-center margin-vertical-2">
+          <button class="button secondary" data-toggler=".volunteer-toggle" data-toggle-class="hide">See More Volunteers</button>
+        </div>
+      {% endif %}
+
+    </div>
+  </section>
+</main>
 {% endblock %}

--- a/weallcode/templates/weallcode/team.html
+++ b/weallcode/templates/weallcode/team.html
@@ -20,9 +20,9 @@
 {% endblock subheader %}
 
 {% block content %}
-<main id="main">
-  {% include "weallcode/snippets/hero_image.html" with src="weallcode/images/photos/hero-team.jpg" alt="our team" %}
+{% include "weallcode/snippets/hero_image.html" with src="weallcode/images/photos/hero-team.jpg" alt="our team" %}
 
+<main id="main">
   <section class="padding-vertical-3">
     <div class="grid-container">
       <div class="grid-x">


### PR DESCRIPTION
This PR addresses accessibility concerns by adding a "skip to main content" link that will be visible to screen readers and via keyboard navigation. It also ensures that there is one main element around the main content of a page so that modern browsers & screen readers can detect the element that has the main ARIA landmark role within the page contents.

Please carefully review details of commit [9fc49a4](https://github.com/WeAllCode/website/commit/9fc49a4cb126b545ec8db2d8346a0f57f6cd1410) of this PR.

I ran through local testing and comparing pages to the live site for these changes. One notable difference is on the `programs` page, the 1px white bottom border that was on the Learn More/Volunteer button in the upcoming classes cards has been removed. I assumed (since this is the only button on the site that has this white border bottom) this was never really intended and happened as consequences of #812, but if that is a wanted design feature I can make adjustments to add it back in for those class buttons.

Closes #828 